### PR TITLE
Update configuration.md

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,7 +42,7 @@ Slots are defined by one or more `[[slots]]` table entries in the `spackle.toml`
 ```toml
 [[slots]]
 key = "slot_name"
-type = "string"
+type = "String"
 name = "Slot name"
 description = "A description of the slot"
 default = "default value"


### PR DESCRIPTION
fixed typo
```
🚰 spackle

❌ Error loading project config
Error parsing contents
TOML parse error at line 5, column 8
  |
5 | type = "string"
  |        ^^^^^^^^
unknown variant `string`, expected one of `Number`, `String`, `Boolean`
```