### PR TITLE
feat: make wasm more importable for spackle-ui

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -25,6 +25,9 @@
     "./wasm/browser": {
       "types": "./dist/wasm/browser.d.ts",
       "default": "./dist/wasm/browser.js"
+    },
+    "./pkg/spackle_wasm_bg.wasm": {
+      "default": "./pkg/spackle_wasm_bg.wasm"
     }
   },
   "scripts": {

--- a/ts/scripts/demo.ts
+++ b/ts/scripts/demo.ts
@@ -3,7 +3,7 @@
 //
 // Run: `just demo-ts` or `cd ts && bun run scripts/demo.ts`
 
-import { cp, mkdtemp, realpath, rm } from "node:fs/promises";
+import { cp, mkdtemp, readFile, realpath, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, relative } from "node:path";
 
@@ -11,6 +11,7 @@ import {
   DiskFs,
   MemoryFs,
   check,
+  configureSpackleWasm,
   generate,
   generateBundle,
   planHooks,
@@ -20,6 +21,9 @@ import {
 
 const REPO_ROOT = join(import.meta.dir, "..", "..");
 const FIXTURES = join(REPO_ROOT, "tests", "fixtures");
+configureSpackleWasm({
+  moduleOrPath: readFile(join(import.meta.dir, "..", "pkg", "spackle_wasm_bg.wasm")),
+});
 
 /** Throwaway workspace seeded with a fixture. */
 async function workspace(fixture: string) {

--- a/ts/src/spackle.ts
+++ b/ts/src/spackle.ts
@@ -228,8 +228,12 @@ export function runHooksStream(
   return inner();
 }
 
-export type { SpackleWasm } from "./wasm/index.ts";
-export { loadSpackleWasm } from "./wasm/index.ts";
+export type {
+  ConfigureSpackleWasmOptions,
+  SpackleWasm,
+  SpackleWasmModuleSource,
+} from "./wasm/index.ts";
+export { configureSpackleWasm, loadSpackleWasm } from "./wasm/index.ts";
 export {
   DiskFs,
   type DiskFsOptions,

--- a/ts/src/wasm/browser.ts
+++ b/ts/src/wasm/browser.ts
@@ -12,9 +12,7 @@ import initWasm, {
 import wasmUrl from "../../pkg/spackle_wasm_bg.wasm?url";
 import { createSpackleWasmLoader } from "./runtime.ts";
 
-/** Load the WASM module once per browser session. Subsequent calls return the
- * same client. Safe to await concurrently. */
-export const loadSpackleWasm = createSpackleWasmLoader(
+export const { loadSpackleWasm, configureSpackleWasm } = createSpackleWasmLoader(
   {
     initWasm,
     check: wasmCheck,
@@ -25,7 +23,11 @@ export const loadSpackleWasm = createSpackleWasmLoader(
   wasmUrl,
 );
 
-export type { SpackleWasm } from "./runtime.ts";
+export type {
+  ConfigureSpackleWasmOptions,
+  SpackleWasm,
+  SpackleWasmModuleSource,
+} from "./runtime.ts";
 export type {
   Bundle,
   BundleEntry,

--- a/ts/src/wasm/index.ts
+++ b/ts/src/wasm/index.ts
@@ -5,6 +5,10 @@
 // preserves the existing package-relative WASM URL behavior for Bun/Node-like
 // runtimes. Browser bundlers should resolve the package export's `browser`
 // condition to `./browser.ts`, which imports the `.wasm` asset directly.
+// Standalone bundle hosts (single-file output via `bun build`, `.deb`
+// payloads, etc.) where `import.meta.url` no longer resolves to the
+// package root should call `configureSpackleWasm({ moduleOrPath })` with
+// their own bytes / URL / module before the first `loadSpackleWasm()`.
 
 import initWasm, {
   check as wasmCheck,
@@ -14,9 +18,7 @@ import initWasm, {
 } from "../../pkg/spackle_wasm.js";
 import { createSpackleWasmLoader } from "./runtime.ts";
 
-/** Load the WASM module once per process. Subsequent calls return the
- * same client. Safe to await concurrently. */
-export const loadSpackleWasm = createSpackleWasmLoader(
+export const { loadSpackleWasm, configureSpackleWasm } = createSpackleWasmLoader(
   {
     initWasm,
     check: wasmCheck,
@@ -27,7 +29,11 @@ export const loadSpackleWasm = createSpackleWasmLoader(
   new URL("../../pkg/spackle_wasm_bg.wasm", import.meta.url),
 );
 
-export type { SpackleWasm } from "./runtime.ts";
+export type {
+  ConfigureSpackleWasmOptions,
+  SpackleWasm,
+  SpackleWasmModuleSource,
+} from "./runtime.ts";
 export type {
   Bundle,
   BundleEntry,

--- a/ts/src/wasm/runtime.ts
+++ b/ts/src/wasm/runtime.ts
@@ -19,6 +19,12 @@ type InitWasm = (
     | Promise<InitInput>,
 ) => Promise<unknown>;
 
+export type SpackleWasmModuleSource = InitInput | Promise<InitInput>;
+
+export interface ConfigureSpackleWasmOptions {
+  moduleOrPath: SpackleWasmModuleSource;
+}
+
 export interface RawWasmExports {
   initWasm: InitWasm;
   check(projectBundle: unknown, projectDir: string): string;
@@ -62,21 +68,44 @@ export interface SpackleWasm {
   ): PlanHooksResponse;
 }
 
+export interface SpackleWasmLoaderPair {
+  loadSpackleWasm: () => Promise<SpackleWasm>;
+  configureSpackleWasm: (options: ConfigureSpackleWasmOptions) => void;
+}
+
 export function createSpackleWasmLoader(
   raw: RawWasmExports,
-  moduleOrPath: InitInput | Promise<InitInput>,
-): () => Promise<SpackleWasm> {
+  defaultModuleOrPath?: SpackleWasmModuleSource,
+): SpackleWasmLoaderPair {
   let cached: Promise<SpackleWasm> | null = null;
+  let override: SpackleWasmModuleSource | null = null;
 
-  return function loadSpackleWasm(): Promise<SpackleWasm> {
-    if (!cached) cached = initialize(raw, moduleOrPath);
+  function configureSpackleWasm(options: ConfigureSpackleWasmOptions): void {
+    if (cached) {
+      throw new Error("configureSpackleWasm must be called before loadSpackleWasm");
+    }
+    override = options.moduleOrPath;
+  }
+
+  function loadSpackleWasm(): Promise<SpackleWasm> {
+    if (!cached) {
+      const source = override ?? defaultModuleOrPath;
+      if (source === undefined) {
+        throw new Error(
+          "Spackle WASM module source is not configured. Call configureSpackleWasm({ moduleOrPath }) before using @a2-ai/spackle.",
+        );
+      }
+      cached = initialize(raw, source);
+    }
     return cached;
-  };
+  }
+
+  return { loadSpackleWasm, configureSpackleWasm };
 }
 
 async function initialize(
   raw: RawWasmExports,
-  moduleOrPath: InitInput | Promise<InitInput>,
+  moduleOrPath: SpackleWasmModuleSource,
 ): Promise<SpackleWasm> {
   await raw.initWasm({ module_or_path: moduleOrPath });
   // wasm-bindgen's generated .d.ts types the JSON / JsValue exports as

--- a/ts/tests/hooks.test.ts
+++ b/ts/tests/hooks.test.ts
@@ -16,6 +16,7 @@ import {
   BunHooks,
   DiskFs,
   NodeHooks,
+  configureSpackleWasm,
   defaultHooks,
   formatArgv,
   parseShellLine,
@@ -30,6 +31,13 @@ import {
 } from "../src/spackle.ts";
 
 const FIXTURES = resolve(import.meta.dir, "..", "..", "tests", "fixtures");
+const WASM = resolve(import.meta.dir, "..", "pkg", "spackle_wasm_bg.wasm");
+
+try {
+  configureSpackleWasm({ moduleOrPath: readFile(WASM) });
+} catch (err) {
+  if (!(err instanceof Error) || !err.message.includes("before loadSpackleWasm")) throw err;
+}
 
 async function workspace(fixture: string) {
   const root = await realpath(await mkdtemp(join(tmpdir(), "spackle-hooks-")));

--- a/ts/tests/spackle.test.ts
+++ b/ts/tests/spackle.test.ts
@@ -12,12 +12,20 @@ import {
   MemoryFs,
   check,
   checkBundle,
+  configureSpackleWasm,
   generate,
   generateBundle,
   validateSlotData,
 } from "../src/spackle.ts";
 
 const FIXTURES = resolve(import.meta.dir, "..", "..", "tests", "fixtures");
+const WASM = resolve(import.meta.dir, "..", "pkg", "spackle_wasm_bg.wasm");
+
+try {
+  configureSpackleWasm({ moduleOrPath: readFile(WASM) });
+} catch (err) {
+  if (!(err instanceof Error) || !err.message.includes("before loadSpackleWasm")) throw err;
+}
 
 async function workspace(fixture: string) {
   const root = await realpath(await mkdtemp(join(tmpdir(), "spackle-")));

--- a/ts/tests/wasm-runtime.test.ts
+++ b/ts/tests/wasm-runtime.test.ts
@@ -1,0 +1,101 @@
+// Focused unit tests for `createSpackleWasmLoader`. Exercise the loader
+// state machine in isolation with a mock `RawWasmExports` so we can assert
+// the default-path, override-path, throw-after-load, and unconfigured-throw
+// branches independently of the package-level singletons that the
+// end-to-end suites in `spackle.test.ts` / `hooks.test.ts` configure at
+// module load time.
+
+import { describe, expect, test } from "bun:test";
+
+import { createSpackleWasmLoader, type RawWasmExports } from "../src/wasm/runtime.ts";
+
+interface MockRaw extends RawWasmExports {
+  initWasmCalls: unknown[];
+}
+
+function mockRaw(): MockRaw {
+  const initWasmCalls: unknown[] = [];
+  return {
+    initWasmCalls,
+    initWasm: (arg) => {
+      initWasmCalls.push(arg);
+      return Promise.resolve(undefined);
+    },
+    check: () =>
+      `{"valid":true,"config":{"name":null,"ignore":[],"slots":[],"hooks":[]},"errors":[]}`,
+    validateSlotData: () => `{"valid":true}`,
+    generate: () => ({ ok: true, files: [], dirs: [] }),
+    planHooks: () => `{"ok":true,"plan":[]}`,
+  };
+}
+
+describe("createSpackleWasmLoader", () => {
+  test("loadSpackleWasm passes the default moduleOrPath to initWasm when no override is set", async () => {
+    const raw = mockRaw();
+    const defaultUrl = new URL("file:///fake/default.wasm");
+    const { loadSpackleWasm } = createSpackleWasmLoader(raw, defaultUrl);
+
+    await loadSpackleWasm();
+
+    expect(raw.initWasmCalls).toEqual([{ module_or_path: defaultUrl }]);
+  });
+
+  test("configureSpackleWasm overrides the default", async () => {
+    const raw = mockRaw();
+    const { loadSpackleWasm, configureSpackleWasm } = createSpackleWasmLoader(
+      raw,
+      new URL("file:///fake/default.wasm"),
+    );
+
+    const overrideBytes = new Uint8Array([0, 1, 2]);
+    configureSpackleWasm({ moduleOrPath: overrideBytes });
+    await loadSpackleWasm();
+
+    expect(raw.initWasmCalls).toEqual([{ module_or_path: overrideBytes }]);
+  });
+
+  test("configureSpackleWasm throws once loadSpackleWasm has been called", async () => {
+    const raw = mockRaw();
+    const { loadSpackleWasm, configureSpackleWasm } = createSpackleWasmLoader(
+      raw,
+      new URL("file:///fake/default.wasm"),
+    );
+
+    await loadSpackleWasm();
+
+    expect(() => configureSpackleWasm({ moduleOrPath: new Uint8Array() })).toThrow(
+      /must be called before loadSpackleWasm/,
+    );
+  });
+
+  test("loadSpackleWasm throws when neither a default nor a configured source is present", () => {
+    const raw = mockRaw();
+    const { loadSpackleWasm } = createSpackleWasmLoader(raw);
+
+    expect(() => loadSpackleWasm()).toThrow(/not configured/);
+    expect(raw.initWasmCalls).toEqual([]);
+  });
+
+  test("loadSpackleWasm succeeds after configureSpackleWasm when there is no default", async () => {
+    const raw = mockRaw();
+    const { loadSpackleWasm, configureSpackleWasm } = createSpackleWasmLoader(raw);
+    const bytes = new Uint8Array([42]);
+
+    configureSpackleWasm({ moduleOrPath: bytes });
+    await loadSpackleWasm();
+
+    expect(raw.initWasmCalls).toEqual([{ module_or_path: bytes }]);
+  });
+
+  test("loadSpackleWasm caches: concurrent and sequential callers share one initWasm call", async () => {
+    const raw = mockRaw();
+    const { loadSpackleWasm } = createSpackleWasmLoader(raw, new URL("file:///fake/default.wasm"));
+
+    const a = loadSpackleWasm();
+    const b = loadSpackleWasm();
+    expect(a).toBe(b);
+
+    await Promise.all([a, b, loadSpackleWasm()]);
+    expect(raw.initWasmCalls).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
we were having bundling issues in spackle-ui when bundling for release using goreleaser; we couldn't load in the wasm due to pathing issues. i am not sure whether this is the most "correct" approach or not but i am currently rebuilding to test if it soulves our issues of running the deb file for bundling purposes