### PR TITLE
feat: accept output_name for render, fix workspaceRoot bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1165,7 +1165,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spackle"
-version = "0.5.1-rc2"
+version = "0.5.1-rc3"
 dependencies = [
  "async-process",
  "async-stream",
@@ -1189,7 +1189,7 @@ dependencies = [
 
 [[package]]
 name = "spackle-cli"
-version = "0.5.1-rc2"
+version = "0.5.1-rc3"
 dependencies = [
  "anyhow",
  "atty",
@@ -1207,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "spackle-wasm"
-version = "0.5.1-rc2"
+version = "0.5.1-rc3"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spackle"
-version = "0.5.1-rc2"
+version = "0.5.1-rc3"
 edition = "2021"
 repository = "https://github.com/a2-ai/spackle"
 description = "A frictionless project templating tool."

--- a/crates/spackle-cli/Cargo.toml
+++ b/crates/spackle-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spackle-cli"
-version = "0.5.1-rc2"
+version = "0.5.1-rc3"
 edition = "2021"
 repository = "https://github.com/a2-ai/spackle"
 

--- a/crates/spackle-wasm/Cargo.toml
+++ b/crates/spackle-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spackle-wasm"
-version = "0.5.1-rc2"
+version = "0.5.1-rc3"
 edition = "2021"
 repository = "https://github.com/a2-ai/spackle"
 description = "wasm-bindgen surface for spackle. Bundle-in / bundle-out pure-function exports."

--- a/crates/spackle-wasm/src/lib.rs
+++ b/crates/spackle-wasm/src/lib.rs
@@ -184,8 +184,9 @@ pub fn validate_slot_data(
 /// the sum of every body in the registry, Tera's parsed templates, and
 /// one rendered string for the target.
 ///
-/// `_project_name` / `_output_name` are not auto-injected; the host
-/// puts them into `slot_data` if templates reference them.
+/// `_project_name` / `_output_name` are not auto-injected here (unlike
+/// [`plan_hooks`]); the host puts them into `slot_data` if templates
+/// reference them.
 ///
 /// Filename templating is separate ([`render_path`]). For a `.j2` file
 /// with a templated name: call `render_path` on the relative path AND
@@ -344,8 +345,22 @@ fn diag_response_path(path_template: &str, message: String) -> JsValue {
 /// Mirrors `Project::run_hooks_stream` at `src/lib.rs:246` in input
 /// shape: `data` is the full data map (slot values + hook toggles keyed
 /// by the hook's own `key`, e.g. `data["my_hook"] = "false"` disables
-/// it). `_project_name` and `_output_name` are injected here to match
-/// native — the caller does NOT pre-inject them.
+/// it).
+///
+/// `_project_name` / `_output_name` injection is **skip-if-present**:
+/// when absent from `data_json`, the defaults — `config.name` (else
+/// basename) and `basename(out_dir)` — are inserted to match
+/// `Project::run_hooks_stream` semantics. When present, the values
+/// `data_json` carries are honored as-is. This is the primitive
+/// contract; how a host arrives at those values is its concern.
+///
+/// Note that this differs from the native `Project::run_hooks_stream`
+/// path, which always-overwrites these keys before templating —
+/// trusting bundle-flow callers to pre-seed means a caller-supplied
+/// `_project_name` does reach the templating context. The disk-flow
+/// TS orchestrator (`runHooksStream` / `planHooks` in `@a2-ai/spackle`)
+/// always pre-seeds its resolved values before calling here, so the
+/// always-overwrite guarantee is preserved at that boundary.
 ///
 /// `hook_ran_json` (optional): JSON of `HashMap<String, bool>` where
 /// keys are hook keys and values are actual execution results. The host
@@ -409,11 +424,15 @@ fn plan_hooks_from_entries(
     // Parity with Project::run_hooks_stream at src/lib.rs:253-254:
     // inject the resolved `_project_name` + `_output_name` so hooks
     // templated with `{{ _output_name }}` render correctly.
-    data.insert("_project_name".to_string(), project.get_name());
-    data.insert(
-        "_output_name".to_string(),
-        spackle::get_output_name(Path::new(out_dir)),
-    );
+    //
+    // Skip-if-present: a host that has computed override names (e.g.
+    // storage path is a UUID but rendered identity is a slug) can
+    // pre-seed `data["_project_name"]` / `data["_output_name"]`. We
+    // honor those instead of clobbering with the config-derived values.
+    data.entry("_project_name".to_string())
+        .or_insert_with(|| project.get_name());
+    data.entry("_output_name".to_string())
+        .or_insert_with(|| spackle::get_output_name(Path::new(out_dir)));
 
     // Merge caller-supplied hook_ran_* overrides. Keys in hook_ran_json
     // are hook keys with boolean values indicating actual execution
@@ -699,6 +718,26 @@ mod plan_hooks_tests {
         let body = names["command"][2].as_str().unwrap();
         assert!(body.contains("hooks-demo"), "got: {}", body);
         assert!(body.contains("my_output"), "got: {}", body);
+    }
+
+    #[test]
+    fn caller_supplied_names_override_defaults() {
+        // Skip-if-present: a host that wants its own render identity
+        // (e.g. storage path is UUID, rendered identity is slug)
+        // pre-seeds `_project_name` / `_output_name` in `data_json`. The
+        // planner must honor those instead of clobbering with the
+        // config-derived values.
+        let plan = call(
+            r#"{"_project_name": "slug-override", "_output_name": "out-override"}"#,
+            None,
+        );
+        let names = find(&plan, "hook_names");
+        let body = names["command"][2].as_str().unwrap();
+        assert!(body.contains("slug-override"), "got: {}", body);
+        assert!(body.contains("out-override"), "got: {}", body);
+        // And the defaults must NOT have leaked through.
+        assert!(!body.contains("hooks-demo"), "got: {}", body);
+        assert!(!body.contains("my_output"), "got: {}", body);
     }
 
     #[test]

--- a/docs/ts/api.md
+++ b/docs/ts/api.md
@@ -96,7 +96,7 @@ function render(
     fs: DiskFs,
     opts?: {
         virtualProjectDir?: string;
-        virtualOutDir?: string;
+        names?: NameOverrides;
     },
 ): Promise<RenderResponse>;
 
@@ -145,7 +145,7 @@ function generate(
     fs: DiskFs,
     opts?: {
         virtualProjectDir?: string;
-        virtualOutDir?: string;
+        names?: NameOverrides;
     },
 ): Promise<GenerateResponse>;
 
@@ -177,6 +177,7 @@ function planHooks(
     opts?: {
         virtualProjectDir?: string;
         hookRan?: Record<string, boolean>;
+        names?: NameOverrides;
     },
 ): Promise<PlanHooksResponse>;
 
@@ -195,7 +196,7 @@ interface HookPlanEntry {
 }
 ```
 
-`data` matches native's `Project::run_hooks_stream` input: slot values PLUS hook toggles keyed by the hook's own `key` (so `data["format_code"] = "false"` disables that hook). `_project_name` / `_output_name` are injected wasm-side — don't pre-inject.
+`data` matches native's `Project::run_hooks_stream` input: slot values PLUS hook toggles keyed by the hook's own `key` (so `data["format_code"] = "false"` disables that hook). `_project_name` and `_output_name` are resolved and injected by the TS orchestrator; any caller-supplied values under those keys are overwritten. `_project_name` follows the rc2 default (`config.name` → `basename(projectDir)`). `_output_name` defaults to `basename(outDir)` but accepts an override via `opts.names.outputName` — see [NameOverrides](#nameoverrides). The override survives every re-plan.
 
 `hookRan` (optional): map of `{ hookKey: actualRanOutcome }`. Hooks present in this map are filtered from the returned plan (host already has their results) while `hook_ran_<key>` is pre-seeded so chained conditionals in downstream hooks evaluate against the real state.
 
@@ -214,6 +215,7 @@ function runHooksStream(
         hooks?: SpackleHooks;     // defaults to defaultHooks()
         cwd?: string;              // defaults to outDir
         env?: Record<string, string>;
+        names?: NameOverrides;
     },
 ): AsyncGenerator<HookEvent>;
 
@@ -306,6 +308,26 @@ No bundle-input variant of `generate` / `render` ships — those are disk-walkin
 
 Pair with `MemoryFs.toBundle()` / `MemoryFs.fromBundle()` to inspect inputs / outputs in-memory.
 
+## `NameOverrides`
+
+Override the rendered `_output_name` independent of the on-disk `outDir`. Solves the staging case: write to `spackle-gen-<uuid>` but render under a stable, human-readable name like `my_cool_project`.
+
+```ts
+interface NameOverrides {
+    outputName?: string;    // overrides _output_name
+}
+```
+
+Resolution for `_output_name`: explicit `outputName` → `basename(outDir)`. Empty string is a valid override (the host explicitly chose it). The override applies to `generate`, `render`, `planHooks`, and `runHooksStream` — and survives every hook re-plan.
+
+`_project_name` is **not** overridable; it stays on the rc2 default (`spackle.toml`'s `name` → `basename(projectDir)`).
+
+```ts
+await generate(projectDir, outDir, slotData, fs, {
+    names: { outputName: "my_cool_project" },
+});
+```
+
 ## Host helpers
 
 ### `DiskFs`
@@ -330,7 +352,7 @@ class DiskFs {
 }
 ```
 
-**Containment.** `workspaceRoot` is canonicalized once. Every path the orchestrator hands back to `DiskFs` resolves under it; anything else throws. Per-entry write paths are joined with `containedJoin` so a rendered path can't escape `outDir` even if a template produced `../`-flavored output. The block uses `path.resolve` + prefix comparison so OS-normalized escapes (Windows `..\`) are caught transparently.
+**Containment.** `workspaceRoot` is canonicalized once at construction. A path is accepted iff its canonical form lives under that root; anything else throws. Per-entry write paths are joined with `containedJoin` so a rendered path can't escape `outDir` even if a template produced `../`-flavored output. The block uses `path.resolve` + prefix comparison so OS-normalized escapes (Windows `..\`) are caught transparently. `workspaceRoot: "/"` is supported on POSIX — pick it when project / output trees may live under unrelated subtrees and you accept the broader trust boundary.
 
 **Streaming.** `streamCopy` uses `pipeline(createReadStream, createWriteStream)`. GB-scale static assets cross the pipe in Node's ~64 KiB chunks; never sit fully in memory. `readFileSync(src) + writeFileSync(dst)` would slurp the whole file into a `Buffer` per copy — never use that pattern in custom orchestrators.
 

--- a/docs/ts/hooks.md
+++ b/docs/ts/hooks.md
@@ -21,7 +21,7 @@ for await (const event of runHooksStream(projectDir, outDir, data, fs)) {
 }
 ```
 
-`data` is a single map, matching native's `Project::run_hooks_stream`. It carries slot values *and* hook toggles (keyed by the hook's own `key`, e.g. `data["format_code"] = "false"` disables the `format_code` hook). `_project_name` and `_output_name` are injected wasm-side — do not pre-inject them.
+`data` is a single map, matching native's `Project::run_hooks_stream`. It carries slot values *and* hook toggles (keyed by the hook's own `key`, e.g. `data["format_code"] = "false"` disables the `format_code` hook). `_project_name` and `_output_name` are resolved by the TS orchestrator and injected automatically — any values under those keys in `data` are overwritten. `_project_name` follows the rc2 default (`config.name` → basename); pass `opts.names: { outputName }` to render under a name different from `basename(outDir)`, useful when writing to a staging dir like `spackle-gen-<uuid>`. The override survives every re-plan. See [`api.md` → NameOverrides](./api.md#nameoverrides).
 
 ## Event shape
 

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2-ai/spackle",
-  "version": "0.5.1-rc2",
+  "version": "0.5.1-rc3",
   "description": "spackle project templating, as a WebAssembly module for JS hosts.",
   "repository": "https://github.com/a2-ai/spackle",
   "files": [

--- a/ts/src/host/disk-fs.ts
+++ b/ts/src/host/disk-fs.ts
@@ -13,8 +13,10 @@ import {
   writeFileSync,
 } from "node:fs";
 import {
+  basename as pathBasename,
   dirname as pathDirname,
   isAbsolute,
+  join as pathJoin,
   resolve as pathResolve,
   sep as pathSep,
 } from "node:path";
@@ -24,9 +26,22 @@ export interface DiskFsOptions {
   /**
    * Absolute path to the workspace root. The adapter refuses any path
    * that canonicalizes outside this root. Must exist on disk at
-   * construction time so it can be canonicalized once.
+   * construction time so it can be canonicalized once. POSIX `"/"` is
+   * supported.
    */
   workspaceRoot: string;
+}
+
+/**
+ * True iff `absPath` lives under `absRoot`. Handles `absRoot === "/"`
+ * correctly: appending `pathSep` would produce `"//"` and reject every
+ * real path, so we detect a root that already ends in the separator
+ * and skip the append.
+ */
+function isContainedUnder(absRoot: string, absPath: string): boolean {
+  if (absPath === absRoot) return true;
+  const prefix = absRoot.endsWith(pathSep) ? absRoot : absRoot + pathSep;
+  return absPath.startsWith(prefix);
 }
 
 export class DiskFs {
@@ -74,10 +89,11 @@ export class DiskFs {
   /** Join `rel` under `absBase` and verify the result stays under it.
    * Catches `../escape`, absolute `rel`, and (on Windows) backslash
    * traversal because `path.resolve` normalizes separators before the
-   * prefix check. */
+   * prefix check. POSIX `absBase === "/"` works correctly — see
+   * [[isContainedUnder]]. */
   containedJoin(absBase: string, rel: string): string {
     const resolved = pathResolve(absBase, rel);
-    if (resolved !== absBase && !resolved.startsWith(absBase + pathSep)) {
+    if (!isContainedUnder(absBase, resolved)) {
       throw new Error(`entry path escapes outDir: ${rel}`);
     }
     return resolved;
@@ -121,7 +137,7 @@ export class DiskFs {
       throw new Error(`path must be absolute: ${path}`);
     }
     const canonical = realpathSync(pathResolve(path));
-    if (canonical !== this.root && !canonical.startsWith(this.root + pathSep)) {
+    if (!isContainedUnder(this.root, canonical)) {
       throw new Error(`path escapes workspaceRoot: ${canonical} not under ${this.root}`);
     }
     return canonical;
@@ -146,14 +162,16 @@ export class DiskFs {
       if (parent === existing) {
         throw new Error(`containDiskForCreate(${path}): no existing ancestor`);
       }
-      tail.unshift(existing.slice(parent.length + 1));
+      // `pathBasename` + `pathJoin` instead of `existing.slice(parent.length + 1)`
+      // and string concat: when `parent === "/"`, the slice form drops an
+      // extra char (existing="/foo" → "oo") and the concat form doubles
+      // the separator (canonicalExisting="/" + sep + tail = "//foo").
+      tail.unshift(pathBasename(existing));
       existing = parent;
     }
     const canonicalExisting = realpathSync(existing);
-    const canonical = tail.length
-      ? `${canonicalExisting}${pathSep}${tail.join(pathSep)}`
-      : canonicalExisting;
-    if (canonical !== this.root && !canonical.startsWith(this.root + pathSep)) {
+    const canonical = tail.length ? pathJoin(canonicalExisting, ...tail) : canonicalExisting;
+    if (!isContainedUnder(this.root, canonical)) {
       throw new Error(`path escapes workspaceRoot: ${canonical} not under ${this.root}`);
     }
     return canonical;

--- a/ts/src/spackle.ts
+++ b/ts/src/spackle.ts
@@ -39,6 +39,24 @@ function stripTemplateExt(name: string): string {
   return name;
 }
 
+/**
+ * Override the rendered output identity. The storage path (`outDir`)
+ * can differ from the name referenced by templates and hook commands
+ * as `{{ _output_name }}` — useful when the host writes to a staging
+ * directory (e.g. `spackle-gen-<uuid>`) but wants the rendered tree to
+ * carry a stable human-readable name (e.g. `my_cool_project`).
+ *
+ * `_project_name` is **not** overridable; it stays on its rc2 default
+ * (`spackle.toml`'s `name` → basename of the project directory).
+ *
+ * Precedence for `_output_name`: explicit `outputName` > `basename(outDir)`.
+ * Empty string is a valid override.
+ */
+export interface NameOverrides {
+  /** Overrides `_output_name`. Beats `basename(outDir)`. */
+  outputName?: string;
+}
+
 export interface CheckOptions {
   /** Virtual path the project bundle is rooted at. Defaults to
    * `/project`; rarely needs overriding. */
@@ -46,9 +64,18 @@ export interface CheckOptions {
 }
 
 export interface GenerateOptions extends CheckOptions {
-  /** Ignored by disk flows — `_output_name` is derived from `outDir`'s
-   * basename. Reserved for a future bundle-input composition. */
-  virtualOutDir?: string;
+  /** Override the rendered `_output_name` independent of `outDir`.
+   * See [[NameOverrides]]. */
+  names?: NameOverrides;
+}
+
+export interface PlanHooksOptions extends CheckOptions {
+  /** Per-hook execution outcome from a prior partial run; surfaces in
+   * subsequent hooks' `if = "{{ hook_ran_<key> }}"` conditionals. */
+  hookRan?: Record<string, boolean>;
+  /** Override the rendered `_output_name` independent of `outDir`.
+   * See [[NameOverrides]]. */
+  names?: NameOverrides;
 }
 
 export interface RunHooksOptions extends CheckOptions {
@@ -58,6 +85,9 @@ export interface RunHooksOptions extends CheckOptions {
   /** Working dir for spawned processes. Defaults to `outDir`. */
   cwd?: string;
   env?: Record<string, string>;
+  /** Override the rendered `_output_name` independent of `outDir`.
+   * See [[NameOverrides]]. */
+  names?: NameOverrides;
 }
 
 // --- walk ---
@@ -202,7 +232,8 @@ function buildConfigOnlyBundle(projectDir: string, virtualRoot: string): Bundle 
 
 // --- slot data injection ---
 
-function get_output_name(outDir: string): string {
+function get_output_name(outDir: string, override?: string): string {
+  if (override !== undefined) return override;
   // `path.basename` handles trailing separators the same way Rust's
   // `Path::file_name` does — "/tmp/out/" → "out", "/" → "".
   const base = pathBasename(outDir);
@@ -222,6 +253,32 @@ function injectSpecials(slotData: SlotData, projectName: string, outputName: str
     _project_name: projectName,
     _output_name: outputName,
   };
+}
+
+/**
+ * Resolve `_project_name` / `_output_name` for a hook flow and inject
+ * them into `data`, ALWAYS overwriting any caller-supplied values.
+ * Matches native parity: the resolved specials are authoritative;
+ * `data["_project_name"] = "evil"` from a host can never reach the
+ * templating context.
+ *
+ * `_project_name` is rc2-default (config.name → basename(projectDir));
+ * `_output_name` honors `overrides.outputName` if present, else
+ * `basename(outDir)`.
+ */
+async function resolveAndInjectHookNames(
+  data: Record<string, string>,
+  bundle: Bundle,
+  virtualDir: string,
+  absProject: string,
+  outDir: string,
+  overrides: NameOverrides | undefined,
+): Promise<Record<string, string>> {
+  const wasm = await loadSpackleWasm();
+  const checkRes = wasm.check(bundle, virtualDir);
+  const projectName = get_project_name(checkRes.config, absProject);
+  const outputName = get_output_name(outDir, overrides?.outputName);
+  return injectSpecials(data, projectName, outputName);
 }
 
 // --- check / validateSlotData ---
@@ -317,7 +374,7 @@ export async function generate(
   }
 
   const projectName = get_project_name(checkRes.config, absProject);
-  const outputName = get_output_name(outDir);
+  const outputName = get_output_name(outDir, opts.names?.outputName);
   const data = injectSpecials(slotData, projectName, outputName);
   const ignore = checkRes.config?.ignore ?? [];
 
@@ -428,7 +485,7 @@ export async function render(
   }
 
   const projectName = get_project_name(checkRes.config, absProject);
-  const outputName = get_output_name(outDir);
+  const outputName = get_output_name(outDir, opts.names?.outputName);
   const data = injectSpecials(slotData, projectName, outputName);
   const ignore = checkRes.config.ignore ?? [];
 
@@ -507,12 +564,20 @@ export async function planHooks(
   outDir: string,
   data: Record<string, string>,
   fs: DiskFs,
-  opts: CheckOptions & { hookRan?: Record<string, boolean> } = {},
+  opts: PlanHooksOptions = {},
 ): Promise<PlanHooksResponse> {
   const absProject = fs.containProject(projectDir);
   const virtualDir = opts.virtualProjectDir ?? DEFAULT_VIRTUAL_PROJECT;
   const bundle = buildConfigOnlyBundle(absProject, virtualDir);
-  return planHooksBundle(bundle, virtualDir, outDir, data, opts.hookRan);
+  const withNames = await resolveAndInjectHookNames(
+    data,
+    bundle,
+    virtualDir,
+    absProject,
+    outDir,
+    opts.names,
+  );
+  return planHooksBundle(bundle, virtualDir, outDir, withNames, opts.hookRan);
 }
 
 /** Bundle pass-through of `planHooks`. */
@@ -532,8 +597,10 @@ export async function planHooksBundle(
  * Executes host-side via `opts.hooks ?? defaultHooks()`.
  *
  * `data` is the full data map (slot values + hook toggles keyed by
- * the hook's raw `key`). `_project_name` / `_output_name` are
- * injected wasm-side.
+ * the hook's raw `key`). `_project_name` is rc2-default (config.name →
+ * basename(projectDir)); `_output_name` honors `opts.names.outputName`
+ * if present (else basename(outDir)) and the override applies across
+ * every re-plan.
  *
  * Non-zero exit continues the run; template render failures are a
  * terminal `template_errors` event.
@@ -550,13 +617,24 @@ export function runHooksStream(
   const bundle = buildConfigOnlyBundle(absProject, virtualDir);
   async function* inner(): AsyncGenerator<HookEvent> {
     const wasm: SpackleWasm = await loadSpackleWasm();
+    // Resolve names once; the resolved data flows back into the planner
+    // on every re-plan so the override (or config-derived default)
+    // stays authoritative.
+    const withNames = await resolveAndInjectHookNames(
+      data,
+      bundle,
+      virtualDir,
+      absProject,
+      outDir,
+      opts.names,
+    );
     yield* runHookPlanStream(
       (b, pdir, odir, d, hookRan) => wasm.planHooks(b, pdir, odir, d, hookRan),
       {
         bundle,
         projectDir: virtualDir,
         outDir,
-        data,
+        data: withNames,
         hooks: opts.hooks,
         cwd: opts.cwd ?? outDir,
         env: opts.env,

--- a/ts/tests/disk-fs.test.ts
+++ b/ts/tests/disk-fs.test.ts
@@ -8,10 +8,16 @@
 //   - `streamCopy` round-trips bytes through `pipeline()`
 
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { randomBytes } from "node:crypto";
 import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+
+/** Hex suffix for collision-proof on-disk test paths. */
+function randomSuffix(): string {
+  return randomBytes(8).toString("hex");
+}
 
 import { DiskFs } from "../src/spackle.ts";
 
@@ -153,4 +159,86 @@ describe("DiskFs", () => {
     await writeFile(join(root, "real"), "x");
     expect(fs.exists(join(root, "real"))).toBe(true);
   });
+});
+
+describe("DiskFs constructor validation", () => {
+  test("relative workspaceRoot throws", () => {
+    expect(() => new DiskFs({ workspaceRoot: "relative/root" })).toThrow(
+      /workspaceRoot must be absolute/,
+    );
+  });
+
+  test("nonexistent workspaceRoot throws", () => {
+    expect(() => new DiskFs({ workspaceRoot: "/nonexistent/spackle-disk-fs-test" })).toThrow(
+      /workspaceRoot not accessible/,
+    );
+  });
+});
+
+// Regression: containment via `startsWith(root + sep)` previously
+// rejected every real path when `workspaceRoot === "/"` because
+// `"/" + "/" === "//"` and no canonical absolute path begins with
+// "//". The fix is in `isContainedUnder` (see disk-fs.ts).
+describe("DiskFs with workspaceRoot: '/'", () => {
+  // Skipping on Windows — POSIX-root semantics don't apply (drive letters).
+  test.skipIf(process.platform === "win32")(
+    "accepts a path under the POSIX root without the // bug",
+    async () => {
+      const tmp = await realpath(await mkdtemp(join(tmpdir(), "spackle-disk-")));
+      try {
+        const fs = new DiskFs({ workspaceRoot: "/" });
+        // realpath of tmp lives under /private/var on macOS; on Linux
+        // it's under /tmp. Either way it's beneath "/" — must contain.
+        expect(fs.containProject(tmp)).toBe(tmp);
+      } finally {
+        await rm(tmp, { recursive: true, force: true });
+      }
+    },
+  );
+
+  test.skipIf(process.platform === "win32")(
+    "containedJoin handles base === '/' without double-slash",
+    () => {
+      const fs = new DiskFs({ workspaceRoot: "/" });
+      // base "/" + rel "tmp/x" must resolve to "/tmp/x" and not get
+      // rejected by an off-by-one prefix check.
+      const rel = `tmp/spackle-disk-${randomSuffix()}`;
+      expect(fs.containedJoin("/", rel)).toBe(`/${rel}`);
+    },
+  );
+
+  // Regression: `containDiskForCreate` used `existing.slice(parent.length + 1)`
+  // and `${canonicalExisting}${sep}${tail.join(sep)}`. When the
+  // nearest existing ancestor is `/`, both forms misbehaved:
+  // - slice("/foo", 1+1) = "oo"
+  // - "/" + "/" + "oo" = "//oo"
+  // The fix uses pathBasename + pathJoin. We randomize the leaf so
+  // the test is collision-proof against anything that may sit at the
+  // POSIX root.
+  test.skipIf(process.platform === "win32")(
+    "assertOutDirAvailable accepts a brand-new top-level path under '/'",
+    () => {
+      const fs = new DiskFs({ workspaceRoot: "/" });
+      // Random-suffixed top-level path; never actually created on disk.
+      const want = `/spackle-disk-fs-test-${randomSuffix()}`;
+      expect(fs.assertOutDirAvailable(want)).toBe(want);
+    },
+  );
+
+  test.skipIf(process.platform === "win32")(
+    "assertOutDirAvailable produces no '//' prefix when the path has multiple new segments under '/'",
+    () => {
+      const fs = new DiskFs({ workspaceRoot: "/" });
+      // Multiple missing segments — every iteration of the
+      // containDiskForCreate loop must produce a clean basename. With
+      // the bug, intermediate segments would lose their leading char
+      // when their parent was `/`.
+      const want = `/spackle-disk-fs-test-${randomSuffix()}/sub/leaf`;
+      const got = fs.assertOutDirAvailable(want);
+      expect(got).toBe(want);
+      // Extra guard: no accidental double-separator anywhere in the
+      // result (a regression of the concat-form join bug).
+      expect(got).not.toContain("//");
+    },
+  );
 });

--- a/ts/tests/hooks.test.ts
+++ b/ts/tests/hooks.test.ts
@@ -158,6 +158,52 @@ describe("planHooks", () => {
       expect(body).toContain("my-output-dir");
     }
   });
+
+  test("caller-supplied _project_name in data is overwritten by the resolved name", async () => {
+    // Native parity + security: a host that accidentally (or
+    // maliciously) sets `data._project_name` must NOT leak into the
+    // templating context. The TS flow re-resolves and always
+    // overwrites. With no override and config.name = "hooks-demo",
+    // the resolved value wins.
+    const ws = await workspace("hooks_fixture");
+    cleanup.push(ws.root);
+    const fs = new DiskFs({ workspaceRoot: ws.root });
+
+    const res = await planHooks(
+      ws.projectDir,
+      join(ws.root, "out"),
+      { _project_name: "EVIL_INJECTION", _output_name: "EVIL_OUT" },
+      fs,
+    );
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      const names = res.plan.find((e) => e.key === "hook_names");
+      const body = names?.command[2];
+      expect(body).toContain("hooks-demo");
+      expect(body).toContain("out");
+      expect(body).not.toContain("EVIL_INJECTION");
+      expect(body).not.toContain("EVIL_OUT");
+    }
+  });
+
+  test("names.outputName override beats basename(outDir)", async () => {
+    const ws = await workspace("hooks_fixture");
+    cleanup.push(ws.root);
+    const fs = new DiskFs({ workspaceRoot: ws.root });
+
+    const outDir = join(ws.root, "uuid-out");
+    const res = await planHooks(ws.projectDir, outDir, {}, fs, {
+      names: { outputName: "slug-out" },
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      const names = res.plan.find((e) => e.key === "hook_names");
+      const body = names?.command[2];
+      expect(body).toContain("hooks-demo"); // _project_name from config.name (no override)
+      expect(body).toContain("slug-out");
+      expect(body).not.toContain("uuid-out");
+    }
+  });
 });
 
 describe("runHooksStream (default runner — actually spawns)", () => {
@@ -189,6 +235,70 @@ describe("runHooksStream (default runner — actually spawns)", () => {
     const names = await readFile(join(ws.outDir, "names.out"), "utf8");
     expect(names).toContain("hooks-demo");
     expect(names).toContain("output"); // basename of ws.outDir
+  });
+
+  test("outputName override end-to-end: side-effect file picks up the rendered slug", async () => {
+    // hook_names writes `'<_project_name>/<_output_name>'` to names.out.
+    // With `outputName` set, the on-disk artifact must carry the slug
+    // on the output side while `_project_name` stays on its rc2
+    // default (config.name = "hooks-demo").
+    const ws = await workspace("hooks_fixture");
+    cleanup.push(ws.root);
+    const fs = new DiskFs({ workspaceRoot: ws.root });
+
+    const { mkdir } = await import("node:fs/promises");
+    await mkdir(ws.outDir, { recursive: true });
+
+    await drain(
+      runHooksStream(ws.projectDir, ws.outDir, {}, fs, {
+        names: { outputName: "my_cool_project" },
+      }),
+    );
+
+    const names = await readFile(join(ws.outDir, "names.out"), "utf8");
+    expect(names).toBe("hooks-demo/my_cool_project");
+  });
+
+  test("outputName override survives a re-plan", async () => {
+    // hooks_fixture chains hook_b on `hook_ran_hook_a`. Failing hook_a
+    // triggers a re-plan; the re-emitted plan must still apply the
+    // outputName override to hook_names' templated command.
+    const ws = await workspace("hooks_fixture");
+    cleanup.push(ws.root);
+    const fs = new DiskFs({ workspaceRoot: ws.root });
+
+    const { mkdir } = await import("node:fs/promises");
+    await mkdir(ws.outDir, { recursive: true });
+
+    // Fail hook_a (its body writes hook_a.out), succeed everything else.
+    const hooks = new MockHooks((cmd) =>
+      cmd[2]?.includes("hook_a.out") ? { exitCode: 1, ok: false } : { exitCode: 0, ok: true },
+    );
+    const events = await drain(
+      runHooksStream(ws.projectDir, ws.outDir, {}, fs, {
+        hooks,
+        names: { outputName: "replan-out-slug" },
+      }),
+    );
+
+    // Initial plan carries the override.
+    const runStart = events.find((e) => e.type === "run_start");
+    expect(runStart?.type).toBe("run_start");
+    if (runStart?.type === "run_start") {
+      const namesEntry = runStart.plan.find((e) => e.key === "hook_names");
+      expect(namesEntry?.command[2]).toContain("replan-out-slug");
+    }
+
+    // After hook_a fails, a replan fires. The re-plan must still
+    // carry the override (proves it isn't a one-time injection).
+    const replan = events.find((e) => e.type === "replan");
+    expect(replan).toBeDefined();
+    if (replan?.type === "replan") {
+      const namesEntry = replan.plan.find((e) => e.key === "hook_names");
+      expect(namesEntry?.command[2]).toContain("replan-out-slug");
+      // basename(ws.outDir) is "output" — must NOT appear in place of the slug.
+      expect(namesEntry?.command[2]).not.toContain("/output");
+    }
   });
 
   test("emits run_start, hook_start/hook_end pairs with timing fields", async () => {

--- a/ts/tests/spackle.test.ts
+++ b/ts/tests/spackle.test.ts
@@ -439,6 +439,104 @@ describe("spackle render (diagnostics-first)", () => {
   });
 });
 
+describe("names overrides", () => {
+  const cleanup: string[] = [];
+  beforeEach(() => void (cleanup.length = 0));
+  afterEach(async () => {
+    await Promise.all(cleanup.map((p) => rm(p, { recursive: true, force: true })));
+  });
+
+  // Fixture: spackle.toml has a name, the file path is templated on
+  // `_output_name`, the body references both specials.
+  // `_project_name` is NOT overridable — it stays on rc2's
+  // config.name → basename(projectDir) fallback. `_output_name`
+  // accepts an override so a project written to a UUID staging dir
+  // can render under a human-readable slug.
+  async function fixture(
+    root: string,
+    opts: { configName?: string } = {},
+  ): Promise<{ projectDir: string; outDir: string }> {
+    const projectDir = join(root, "spackle-gen-uuid");
+    await mkdir(projectDir, { recursive: true });
+    const configName = opts.configName === undefined ? "" : `name = "${opts.configName}"\n`;
+    await writeFile(
+      join(projectDir, "spackle.toml"),
+      `${configName}[[slots]]\nkey = "noop"\ntype = "String"\n`,
+    );
+    await writeFile(
+      join(projectDir, "{{ _output_name }}.txt.j2"),
+      "project={{ _project_name }}, output={{ _output_name }}",
+    );
+    return { projectDir, outDir: join(root, "spackle-gen-out-uuid") };
+  }
+
+  test("generate: names.outputName beats basename(outDir); _project_name stays on config.name", async () => {
+    const root = await realpath(await mkdtemp(join(tmpdir(), "spackle-names-")));
+    cleanup.push(root);
+    const { projectDir, outDir } = await fixture(root, { configName: "my_cool_project" });
+
+    const fs = new DiskFs({ workspaceRoot: root });
+    const res = await generate(projectDir, outDir, { noop: "x" }, fs, {
+      names: { outputName: "rendered_slug" },
+    });
+    expect(res.ok).toBe(true);
+
+    // Path templated with the override.
+    const rendered = await readFile(join(outDir, "rendered_slug.txt"), "utf8");
+    expect(rendered).toBe("project=my_cool_project, output=rendered_slug");
+  });
+
+  test("generate: omitted override keeps rc2 defaults for both specials", async () => {
+    const root = await realpath(await mkdtemp(join(tmpdir(), "spackle-names-")));
+    cleanup.push(root);
+    // No config.name → _project_name falls back to basename(projectDir).
+    const { projectDir, outDir } = await fixture(root, { configName: undefined });
+
+    const fs = new DiskFs({ workspaceRoot: root });
+    const res = await generate(projectDir, outDir, { noop: "x" }, fs);
+    expect(res.ok).toBe(true);
+    // basename(outDir) = "spackle-gen-out-uuid"; basename(projectDir) = "spackle-gen-uuid".
+    const rendered = await readFile(join(outDir, "spackle-gen-out-uuid.txt"), "utf8");
+    expect(rendered).toBe("project=spackle-gen-uuid, output=spackle-gen-out-uuid");
+  });
+
+  test("render: outputName override flows through the diagnostics-first path", async () => {
+    const root = await realpath(await mkdtemp(join(tmpdir(), "spackle-names-")));
+    cleanup.push(root);
+    const { projectDir, outDir } = await fixture(root, { configName: "from-config" });
+
+    const fs = new DiskFs({ workspaceRoot: root });
+    const res = await render(projectDir, outDir, { noop: "x" }, fs, {
+      names: { outputName: "render-out" },
+    });
+    expect(res.diagnostics).toEqual([]);
+    const entry = res.files.find((f) => f.path.endsWith("render-out.txt"));
+    expect(entry).toBeDefined();
+    expect(new TextDecoder().decode(entry!.bytes)).toBe("project=from-config, output=render-out");
+  });
+
+  test("outputName override accepts the empty string", async () => {
+    // Empty string is a meaningful explicit choice from the host.
+    const root = await realpath(await mkdtemp(join(tmpdir(), "spackle-names-")));
+    cleanup.push(root);
+    const projectDir = join(root, "proj");
+    await mkdir(projectDir, { recursive: true });
+    await writeFile(
+      join(projectDir, "spackle.toml"),
+      'name = "cfg"\n[[slots]]\nkey = "noop"\ntype = "String"\n',
+    );
+    await writeFile(join(projectDir, "body.txt.j2"), "out=[{{ _output_name }}]");
+    const outDir = join(root, "outdir-basename");
+    const fs = new DiskFs({ workspaceRoot: root });
+    const res = await generate(projectDir, outDir, { noop: "x" }, fs, {
+      names: { outputName: "" },
+    });
+    expect(res.ok).toBe(true);
+    const body = await readFile(join(outDir, "body.txt"), "utf8");
+    expect(body).toBe("out=[]");
+  });
+});
+
 describe("checkBundle (in-memory)", () => {
   test("clean project bundle has no diagnostics", async () => {
     // checkBundle is a 1:1 pass-through over wasm.check, useful for


### PR DESCRIPTION
Adds an `_output_name` render override and fixes POSIX-`/` containment in `DiskFs`. Solves the staging case where the consumer writes to `spackle-gen-<uuid>` but wants the rendered tree to carry a stable name like `my_cool_project`, and lets a single permissive workspace root span unrelated directory subtrees.


#### `names.outputName` override on the high-level disk APIs

`generate`, `render`, `planHooks`, and `runHooksStream` accept a new `opts.names: { outputName?: string }`. When set, the override (empty string included) replaces `basename(outDir)` everywhere `{{ _output_name }}` is templated — file paths, template bodies, and hook commands — and it survives every hook re-plan.

```ts
await generate(projectDir, outDir, slotData, fs, {
  names: { outputName: "my_cool_project" },
});
```

`_project_name` is **not** overridable; it stays on its rc2 default (`spackle.toml`'s `name` → `basename(projectDir)`).

Resolution / injection moves into the TS orchestrator: hook flows now call `wasm.check` once, resolve both special keys, and always pre-seed `data` before invoking the planner — so caller-supplied `data._project_name` / `data._output_name` keys can't leak into the templating context, matching native's always-overwrite guarantee at the disk boundary.

#### Wasm `plan_hooks` becomes skip-if-present

`crates/spackle-wasm` now inserts `_project_name` / `_output_name` via `or_insert_with` rather than always-overwrite. The wasm boundary stays a clean primitive — the TS orchestrator owns resolution policy and pre-seeds; bundle-flow callers can deliberately supply their own values.

#### `DiskFs` accepts `workspaceRoot: "/"` on POSIX

Containment used `path.startsWith(root + sep)`, which for `root === "/"` became `startsWith("//")` and rejected every real canonical path. `containDiskForCreate` had the same root cause in its slice/concat math: with the nearest existing ancestor being `/`, `/foo` produced tail `"oo"` and joined as `"//oo"`.

Fix uses a single `isContainedUnder` helper that skips the separator append when the root already ends in one, and `pathBasename` + `pathJoin` in the create path. `workspaceRoot: "/"` now works end-to-end for `containProject`, `containedJoin`, `assertOutDirAvailable`, and `ensureOutDir`.
