### PR TITLE
feat: normalize and wrap chained hook commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1165,7 +1165,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spackle"
-version = "0.5.1-rc2"
+version = "0.5.1-rc3"
 dependencies = [
  "async-process",
  "async-stream",
@@ -1189,7 +1189,7 @@ dependencies = [
 
 [[package]]
 name = "spackle-cli"
-version = "0.5.1-rc2"
+version = "0.5.1-rc3"
 dependencies = [
  "anyhow",
  "atty",
@@ -1207,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "spackle-wasm"
-version = "0.5.1-rc2"
+version = "0.5.1-rc3"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spackle"
-version = "0.5.1-rc2"
+version = "0.5.1-rc3"
 edition = "2021"
 repository = "https://github.com/a2-ai/spackle"
 description = "A frictionless project templating tool."

--- a/crates/spackle-cli/Cargo.toml
+++ b/crates/spackle-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spackle-cli"
-version = "0.5.1-rc2"
+version = "0.5.1-rc3"
 edition = "2021"
 repository = "https://github.com/a2-ai/spackle"
 

--- a/crates/spackle-wasm/Cargo.toml
+++ b/crates/spackle-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spackle-wasm"
-version = "0.5.1-rc2"
+version = "0.5.1-rc3"
 edition = "2021"
 repository = "https://github.com/a2-ai/spackle"
 description = "wasm-bindgen surface for spackle. Bundle-in / bundle-out pure-function exports."

--- a/crates/spackle-wasm/src/lib.rs
+++ b/crates/spackle-wasm/src/lib.rs
@@ -192,11 +192,7 @@ pub fn validate_slot_data(
 /// `render_file` on the body, then strip the trailing extension
 /// host-side.
 #[wasm_bindgen]
-pub fn render_file(
-    template_bundle: JsValue,
-    target_path: &str,
-    slot_data_json: &str,
-) -> JsValue {
+pub fn render_file(template_bundle: JsValue, target_path: &str, slot_data_json: &str) -> JsValue {
     let entries = match decode_bundle(template_bundle) {
         Ok(e) => e,
         Err(msg) => return diag_response_file(target_path, msg),
@@ -237,9 +233,7 @@ pub fn render_file(
                 spackle::template::FileErrorKind::ErrorRenderingContents(e) => {
                     (e.to_string(), Some(e))
                 }
-                spackle::template::FileErrorKind::ErrorRenderingName(e) => {
-                    (e.to_string(), Some(e))
-                }
+                spackle::template::FileErrorKind::ErrorRenderingName(e) => (e.to_string(), Some(e)),
                 other => (other.to_string(), None),
             };
             let mut diag = spackle::Diagnostic::new(
@@ -533,12 +527,30 @@ fn plan_hooks_native_parity(
             continue;
         }
 
+        // Auto-wrap chained shell commands before templating. Mirrors
+        // `spackle::hook::evaluate_hook_plan` — detection on the raw
+        // command, collision is a hard plan-stage error.
+        let command_to_template =
+            match spackle::hook::normalize_hook_command_for_execution(&hook.command) {
+                Ok(normalized) => normalized,
+                Err(e) => {
+                    results.push(HookPlanEntry {
+                        key: hook.key.clone(),
+                        command: hook.command.clone(),
+                        should_run: false,
+                        skip_reason: Some("template_error".to_string()),
+                        template_errors: vec![format!("hook '{}': {}", hook.key, e)],
+                    });
+                    continue;
+                }
+            };
+
         let context = match Context::from_serialize(&running) {
             Ok(c) => c,
             Err(e) => {
                 results.push(HookPlanEntry {
                     key: hook.key.clone(),
-                    command: hook.command.clone(),
+                    command: command_to_template,
                     should_run: false,
                     skip_reason: Some("template_error".to_string()),
                     template_errors: vec![format!("context error: {}", e)],
@@ -548,8 +560,7 @@ fn plan_hooks_native_parity(
         };
 
         let mut template_errors = Vec::new();
-        let templated_command: Vec<String> = hook
-            .command
+        let templated_command: Vec<String> = command_to_template
             .iter()
             .map(|arg| match Tera::one_off(arg, &context, false) {
                 Ok(rendered) => rendered,
@@ -852,6 +863,86 @@ default = true
             masked["template_errors"].is_array(),
             "template_errors array missing: {}",
             masked
+        );
+    }
+
+    #[test]
+    fn chained_command_auto_wrapped_in_plan() {
+        let toml = br#"
+[[hooks]]
+key = "chain"
+command = ["git", "init", "&&", "git", "add", "."]
+default = true
+"#;
+        let entries = vec![BundleEntry {
+            path: "/project/spackle.toml".to_string(),
+            bytes: toml.to_vec(),
+        }];
+        let plan = call_with_bundle(entries, "{}", None);
+        let chain = plan
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|e| e["key"] == "chain")
+            .unwrap();
+        assert_eq!(chain["should_run"], true, "got: {}", chain);
+        assert_eq!(chain["command"][0], "bash");
+        assert_eq!(chain["command"][1], "-c");
+        assert_eq!(chain["command"][2], "git init && git add .");
+    }
+
+    #[test]
+    fn chained_command_with_template_yields_template_error() {
+        let toml = br#"
+[[hooks]]
+key = "broken"
+command = ["echo", "{{ name }}", "&&", "echo", "done"]
+default = true
+"#;
+        let entries = vec![BundleEntry {
+            path: "/project/spackle.toml".to_string(),
+            bytes: toml.to_vec(),
+        }];
+        let plan = call_with_bundle(entries, r#"{"name": "hi"}"#, None);
+        let broken = plan
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|e| e["key"] == "broken")
+            .unwrap();
+        assert_eq!(broken["should_run"], false, "got: {}", broken);
+        assert_eq!(broken["skip_reason"], "template_error");
+        let errs = broken["template_errors"].as_array().unwrap();
+        assert!(
+            errs[0].as_str().unwrap().contains("shell injection"),
+            "expected shell injection mention, got: {}",
+            errs[0]
+        );
+    }
+
+    #[test]
+    fn chained_command_preserves_quoted_args() {
+        let toml = br#"
+[[hooks]]
+key = "commit"
+command = ["git", "commit", "-m", "initial commit", "&&", "git", "status"]
+default = true
+"#;
+        let entries = vec![BundleEntry {
+            path: "/project/spackle.toml".to_string(),
+            bytes: toml.to_vec(),
+        }];
+        let plan = call_with_bundle(entries, "{}", None);
+        let commit = plan
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|e| e["key"] == "commit")
+            .unwrap();
+        assert_eq!(commit["should_run"], true);
+        assert_eq!(
+            commit["command"][2],
+            "git commit -m 'initial commit' && git status"
         );
     }
 }

--- a/crates/spackle-wasm/src/lib.rs
+++ b/crates/spackle-wasm/src/lib.rs
@@ -482,7 +482,7 @@ fn plan_hooks_native_parity(
 ) -> Vec<spackle::hook::HookPlanEntry> {
     use spackle::hook::HookPlanEntry;
     use spackle::needs::Needy;
-    use tera::{Context, Tera};
+    use tera::Context;
 
     let items: Vec<&dyn Needy> = {
         let mut v: Vec<&dyn Needy> = slots.iter().map(|s| s as &dyn Needy).collect();
@@ -508,7 +508,7 @@ fn plan_hooks_native_parity(
         if !hook.is_enabled(&running) {
             results.push(HookPlanEntry {
                 key: hook.key.clone(),
-                command: hook.command.clone(),
+                command: hook.command.display_argv(),
                 should_run: false,
                 skip_reason: Some("user_disabled".to_string()),
                 template_errors: vec![],
@@ -519,7 +519,7 @@ fn plan_hooks_native_parity(
         if !hook.is_satisfied(&items, &running) {
             results.push(HookPlanEntry {
                 key: hook.key.clone(),
-                command: hook.command.clone(),
+                command: hook.command.display_argv(),
                 should_run: false,
                 skip_reason: Some("unsatisfied_needs".to_string()),
                 template_errors: vec![],
@@ -527,30 +527,15 @@ fn plan_hooks_native_parity(
             continue;
         }
 
-        // Auto-wrap chained shell commands before templating. Mirrors
-        // `spackle::hook::evaluate_hook_plan` — detection on the raw
-        // command, collision is a hard plan-stage error.
-        let command_to_template =
-            match spackle::hook::normalize_hook_command_for_execution(&hook.command) {
-                Ok(normalized) => normalized,
-                Err(e) => {
-                    results.push(HookPlanEntry {
-                        key: hook.key.clone(),
-                        command: hook.command.clone(),
-                        should_run: false,
-                        skip_reason: Some("template_error".to_string()),
-                        template_errors: vec![format!("hook '{}': {}", hook.key, e)],
-                    });
-                    continue;
-                }
-            };
-
+        // Render the command into its full `bash -c` argv, then run the
+        // denylist on argv[2] (the `-c` body). Mirrors
+        // `spackle::hook::evaluate_hook_plan`.
         let context = match Context::from_serialize(&running) {
             Ok(c) => c,
             Err(e) => {
                 results.push(HookPlanEntry {
                     key: hook.key.clone(),
-                    command: command_to_template,
+                    command: hook.command.display_argv(),
                     should_run: false,
                     skip_reason: Some("template_error".to_string()),
                     template_errors: vec![format!("context error: {}", e)],
@@ -559,28 +544,32 @@ fn plan_hooks_native_parity(
             }
         };
 
-        let mut template_errors = Vec::new();
-        let templated_command: Vec<String> = command_to_template
-            .iter()
-            .map(|arg| match Tera::one_off(arg, &context, false) {
-                Ok(rendered) => rendered,
-                Err(e) => {
-                    template_errors.push(format!("arg {:?}: {}", arg, e));
-                    arg.clone()
-                }
-            })
-            .collect();
+        let argv = match spackle::hook::render_command(&hook.command, &context) {
+            Ok(argv) => argv,
+            Err(e) => {
+                results.push(HookPlanEntry {
+                    key: hook.key.clone(),
+                    command: hook.command.display_argv(),
+                    should_run: false,
+                    skip_reason: Some("template_error".to_string()),
+                    template_errors: vec![format!("hook '{}': {}", hook.key, e)],
+                });
+                continue;
+            }
+        };
 
-        if !template_errors.is_empty() {
+        if let Err(e) = spackle::hook::dangerous_pattern_check(&argv[2]) {
             results.push(HookPlanEntry {
                 key: hook.key.clone(),
-                command: templated_command,
+                command: argv,
                 should_run: false,
                 skip_reason: Some("template_error".to_string()),
-                template_errors,
+                template_errors: vec![format!("hook '{}': {}", hook.key, e)],
             });
             continue;
         }
+
+        let wrapped = argv;
 
         // Conditional evaluation runs AFTER templating — native parity.
         // A hook whose command templates cleanly but whose `if` is false
@@ -590,7 +579,7 @@ fn plan_hooks_native_parity(
             Ok(false) => {
                 results.push(HookPlanEntry {
                     key: hook.key.clone(),
-                    command: templated_command,
+                    command: wrapped,
                     should_run: false,
                     skip_reason: Some("false_conditional".to_string()),
                     template_errors: vec![],
@@ -600,7 +589,7 @@ fn plan_hooks_native_parity(
             Err(e) => {
                 results.push(HookPlanEntry {
                     key: hook.key.clone(),
-                    command: templated_command,
+                    command: wrapped,
                     should_run: false,
                     skip_reason: Some(format!("conditional_error: {}", e)),
                     template_errors: vec![],
@@ -612,7 +601,7 @@ fn plan_hooks_native_parity(
 
         results.push(HookPlanEntry {
             key: hook.key.clone(),
-            command: templated_command,
+            command: wrapped,
             should_run: true,
             skip_reason: None,
             template_errors: vec![],
@@ -829,7 +818,10 @@ default = true
         assert!(h.get("template_errors").is_none(), "got: {}", h);
         // upper("hello world") = "HELLO WORLD" — asserts the filter
         // actually ran, not just that the raw template passed through.
-        assert_eq!(h["command"][1], "HELLO WORLD", "got: {}", h);
+        // Array form renders each element then POSIX-quotes it into the
+        // `bash -c` body.
+        assert_eq!(h["command"][0], "bash");
+        assert_eq!(h["command"][2], "echo 'HELLO WORLD'", "got: {}", h);
     }
 
     #[test]
@@ -892,10 +884,12 @@ default = true
     }
 
     #[test]
-    fn chained_command_with_template_yields_template_error() {
+    fn chained_command_with_template_is_literal_and_safe() {
+        // Template-then-quote: the slot value becomes a literal argument, so
+        // mixing operators and templates is safe (no longer a hard error).
         let toml = br#"
 [[hooks]]
-key = "broken"
+key = "first"
 command = ["echo", "{{ name }}", "&&", "echo", "done"]
 default = true
 "#;
@@ -903,19 +897,129 @@ default = true
             path: "/project/spackle.toml".to_string(),
             bytes: toml.to_vec(),
         }];
-        let plan = call_with_bundle(entries, r#"{"name": "hi"}"#, None);
-        let broken = plan
+        let plan = call_with_bundle(entries, r#"{"name": "evil; rm x"}"#, None);
+        let first = plan
             .as_array()
             .unwrap()
             .iter()
-            .find(|e| e["key"] == "broken")
+            .find(|e| e["key"] == "first")
             .unwrap();
-        assert_eq!(broken["should_run"], false, "got: {}", broken);
-        assert_eq!(broken["skip_reason"], "template_error");
-        let errs = broken["template_errors"].as_array().unwrap();
+        assert_eq!(first["should_run"], true, "got: {}", first);
+        assert_eq!(first["command"][0], "bash");
+        assert_eq!(first["command"][2], "echo 'evil; rm x' && echo done");
+    }
+
+    #[test]
+    fn string_form_command_raw_substitution_in_plan() {
+        let toml = br#"
+[[hooks]]
+key = "s"
+command = "echo {{ name }} && echo done"
+default = true
+"#;
+        let entries = vec![BundleEntry {
+            path: "/project/spackle.toml".to_string(),
+            bytes: toml.to_vec(),
+        }];
+        let plan = call_with_bundle(entries, r#"{"name": "hi"}"#, None);
+        let s = plan
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|e| e["key"] == "s")
+            .unwrap();
+        assert_eq!(s["should_run"], true, "got: {}", s);
+        assert_eq!(s["command"][2], "echo hi && echo done");
+    }
+
+    #[test]
+    fn dangerous_command_blocked_in_plan() {
+        let toml = br#"
+[[hooks]]
+key = "danger"
+command = "rm -rf /"
+default = true
+"#;
+        let entries = vec![BundleEntry {
+            path: "/project/spackle.toml".to_string(),
+            bytes: toml.to_vec(),
+        }];
+        let plan = call_with_bundle(entries, "{}", None);
+        let danger = plan
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|e| e["key"] == "danger")
+            .unwrap();
+        assert_eq!(danger["should_run"], false, "got: {}", danger);
+        assert_eq!(danger["skip_reason"], "template_error");
+        let errs = danger["template_errors"].as_array().unwrap();
         assert!(
-            errs[0].as_str().unwrap().contains("shell injection"),
-            "expected shell injection mention, got: {}",
+            errs[0].as_str().unwrap().contains("dangerous"),
+            "expected dangerous-pattern mention, got: {}",
+            errs[0]
+        );
+    }
+
+    #[test]
+    fn string_form_non_padded_separator_does_not_bypass_denylist() {
+        // The separator is not whitespace-padded, but the trailing `rm` must
+        // still be recognized as a command and blocked.
+        let toml = br#"
+[[hooks]]
+key = "sneaky"
+command = "echo safe;rm -rf /"
+default = true
+"#;
+        let entries = vec![BundleEntry {
+            path: "/project/spackle.toml".to_string(),
+            bytes: toml.to_vec(),
+        }];
+        let plan = call_with_bundle(entries, "{}", None);
+        let sneaky = plan
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|e| e["key"] == "sneaky")
+            .unwrap();
+        assert_eq!(sneaky["should_run"], false, "got: {}", sneaky);
+        assert_eq!(sneaky["skip_reason"], "template_error");
+        let errs = sneaky["template_errors"].as_array().unwrap();
+        assert!(
+            errs[0].as_str().unwrap().contains("dangerous"),
+            "expected dangerous-pattern mention, got: {}",
+            errs[0]
+        );
+    }
+
+    #[test]
+    fn bash_c_with_positionals_does_not_bypass_denylist() {
+        // A `bash -c` array with extra positional args must not slip a
+        // slot-injected `rm -rf /` past the denylist — the `-c` body is
+        // scanned directly.
+        let toml = br#"
+[[hooks]]
+key = "sneaky"
+command = ["bash", "-c", "rm -rf {{ target }}", "x"]
+default = true
+"#;
+        let entries = vec![BundleEntry {
+            path: "/project/spackle.toml".to_string(),
+            bytes: toml.to_vec(),
+        }];
+        let plan = call_with_bundle(entries, r#"{"target": "/"}"#, None);
+        let sneaky = plan
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|e| e["key"] == "sneaky")
+            .unwrap();
+        assert_eq!(sneaky["should_run"], false, "got: {}", sneaky);
+        assert_eq!(sneaky["skip_reason"], "template_error");
+        let errs = sneaky["template_errors"].as_array().unwrap();
+        assert!(
+            errs[0].as_str().unwrap().contains("dangerous"),
+            "expected dangerous-pattern mention, got: {}",
             errs[0]
         );
     }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -121,54 +121,50 @@ name = "Create a new file"
 description = "Create a new file called new_file"
 ```
 
-#### Command sequences
+#### Command forms and substitution
 
-To manage hook command sequences, create a single hook that runs a shell command, invoking your desired commands in sequence. For example:
+Every hook runs under `bash -c`, so chaining commands works without any special handling. `bash` must be on `PATH` at hook-execution time (Linux and macOS). `command` accepts two forms, which differ in how templated slot values are substituted:
+
+**String form** — templated as a whole, then run via `bash -c`. Slot values substitute as **raw shell text**, so you own quoting. Use this when you want shell semantics from a slot value, or just for readability:
 
 ```toml
-[[hooks]]
-key = "create_file"
-command = ["bash", "-c", "touch new_file && chmod +x new_file"]
+command = "touch new_file && chmod +x new_file"
+
+# Raw substitution — quote it yourself if the value should stay literal:
+command = "echo '{{ name }}' && echo done"
 ```
 
-##### Automatic shell wrapping
-
-If your command contains a bare shell operator (`&&`, `||`, `|`, `;`) as its own argv element, spackle automatically wraps the command in `bash -c` before execution. Both forms below behave identically:
+**Array form** — each element is templated, then POSIX-quoted (bare shell operators `&&`, `||`, `|`, `;` pass through), then joined and run via `bash -c`. Slot values become **literal arguments** and can never act as shell syntax:
 
 ```toml
-# explicit
-command = ["bash", "-c", "touch new_file && chmod +x new_file"]
-
-# auto-wrapped to the form above
 command = ["touch", "new_file", "&&", "chmod", "+x", "new_file"]
-```
 
-Args that contain whitespace or shell metacharacters are POSIX-quoted when wrapped, so values like `-m "initial commit"` survive intact:
-
-```toml
+# Whitespace and metacharacters in a value are quoted automatically:
 command = ["git", "commit", "-m", "initial commit", "&&", "git", "status"]
-# wrapped to: ["bash", "-c", "git commit -m 'initial commit' && git status"]
+# runs: git commit -m 'initial commit' && git status
+
+# A slot value can't break out — it stays one argument:
+command = ["touch", "{{ name }}"]
+# name = "weird; rm x"  →  touch 'weird; rm x'   (one file, no injection)
 ```
 
-Auto-wrap **only** triggers on standalone whitespace-separated argv elements — `"&&"` as its own element triggers wrapping, but the string `"a&&b"` is left untouched.
+An array of the shape `["bash"|"sh", "-c", body]` is treated as the string form: `body` is templated and run via `bash -c`.
 
-Auto-wrap is **disabled** when any command element contains a template expression (`{{ ... }}`, `{% ... %}`, `{# ... #}`). Wrapping templated values into a shell string would let slot values inject shell metacharacters, so spackle errors at plan time. If you want template substitution inside a shell-evaluated command, use the explicit form and quote your templated values yourself:
+##### Blocked patterns
 
-```toml
-command = ["bash", "-c", "echo '{{ name }}' && echo done"]
-```
-
-Auto-wrap uses `bash -c`; `bash` must be available on `PATH` at hook-execution time. Supported on Linux and macOS.
+Hooks run as the invoking user, so the blast radius is whatever that user could already type at their shell. spackle still refuses a small denylist of unambiguously catastrophic rendered commands — a fork bomb, or a recursive force-remove of `/` or a top-level system directory (`rm -rf /`, `rm -rf /etc`, …). These are caught at plan time and the hook does not run.
 
 ### key `string`
 
 The identifier for the hook.
 
-### command `string[]` <span style="color: darkseagreen;">{s}</span>
+### command `string` or `string[]` <span style="color: darkseagreen;">{s}</span>
 
-The command to execute. The first element is the command and the rest are arguments. Accepts values from slots.
+The command to execute, in either string or array form (see [Command forms and substitution](#command-forms-and-substitution)). Accepts values from slots. Runs under `bash -c`.
 
 ```toml
+command = "echo Hello {{ foo }}"
+# or
 command = ["echo", "Hello {{ foo }}"]
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -131,6 +131,35 @@ key = "create_file"
 command = ["bash", "-c", "touch new_file && chmod +x new_file"]
 ```
 
+##### Automatic shell wrapping
+
+If your command contains a bare shell operator (`&&`, `||`, `|`, `;`) as its own argv element, spackle automatically wraps the command in `bash -c` before execution. Both forms below behave identically:
+
+```toml
+# explicit
+command = ["bash", "-c", "touch new_file && chmod +x new_file"]
+
+# auto-wrapped to the form above
+command = ["touch", "new_file", "&&", "chmod", "+x", "new_file"]
+```
+
+Args that contain whitespace or shell metacharacters are POSIX-quoted when wrapped, so values like `-m "initial commit"` survive intact:
+
+```toml
+command = ["git", "commit", "-m", "initial commit", "&&", "git", "status"]
+# wrapped to: ["bash", "-c", "git commit -m 'initial commit' && git status"]
+```
+
+Auto-wrap **only** triggers on standalone whitespace-separated argv elements — `"&&"` as its own element triggers wrapping, but the string `"a&&b"` is left untouched.
+
+Auto-wrap is **disabled** when any command element contains a template expression (`{{ ... }}`, `{% ... %}`, `{# ... #}`). Wrapping templated values into a shell string would let slot values inject shell metacharacters, so spackle errors at plan time. If you want template substitution inside a shell-evaluated command, use the explicit form and quote your templated values yourself:
+
+```toml
+command = ["bash", "-c", "echo '{{ name }}' && echo done"]
+```
+
+Auto-wrap uses `bash -c`; `bash` must be available on `PATH` at hook-execution time. Supported on Linux and macOS.
+
 ### key `string`
 
 The identifier for the hook.

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -116,6 +116,125 @@ impl Hook {
     }
 }
 
+const SHELL_OPERATORS: &[&str] = &["&&", "||", "|", ";"];
+
+#[derive(Debug, thiserror::Error)]
+pub enum HookCommandError {
+    #[error(
+        "shell operators ({operators}) combined with template syntax in command elements: \
+         auto-wrap is unsafe (shell injection risk via slot values). \
+         Use explicit command = [\"bash\", \"-c\", \"...\"] and quote templated values yourself."
+    )]
+    OperatorTemplateCollision { operators: String },
+}
+
+fn posix_quote(s: &str) -> String {
+    if s.is_empty() {
+        return "''".to_string();
+    }
+    if s.chars().all(|c| {
+        c.is_ascii_alphanumeric()
+            || matches!(c, '_' | '-' | '/' | '.' | ':' | '=' | '@' | ',' | '+')
+    }) {
+        return s.to_string();
+    }
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('\'');
+    for c in s.chars() {
+        if c == '\'' {
+            out.push_str("'\\''");
+        } else {
+            out.push(c);
+        }
+    }
+    out.push('\'');
+    out
+}
+
+fn contains_operator_token(s: &str) -> bool {
+    s.split_whitespace()
+        .any(|tok| SHELL_OPERATORS.contains(&tok))
+}
+
+fn contains_tera_syntax(s: &str) -> bool {
+    s.contains("{{") || s.contains("{%") || s.contains("{#")
+}
+
+/// Normalize a hook command for execution.
+///
+/// - Returns the input unchanged when no shell operators are present, or
+///   when the command is already wrapped (`["bash"|"sh", "-c", ...]`).
+/// - When any element is exactly `&&`, `||`, `|`, or `;` (OR the command
+///   is a single-element vec whose lone string contains an operator
+///   token as a whitespace-bounded word), rewrites the command to
+///   `["bash", "-c", "<POSIX-quoted body>"]`.
+/// - Errors when wrap would trigger AND any element contains Tera
+///   syntax (`{{`, `{%`, `{#`) — the author must use explicit
+///   `["bash", "-c", "..."]` so they own shell-safety of substituted
+///   values.
+///
+/// Idempotent — safe to call from both the planner and the executor.
+pub fn normalize_hook_command_for_execution(
+    command: &[String],
+) -> Result<Vec<String>, HookCommandError> {
+    if command.is_empty() {
+        return Ok(command.to_vec());
+    }
+
+    // Already-wrapped guard: `["bash"|"sh", "-c", ...]`.
+    if command.len() >= 2 && (command[0] == "bash" || command[0] == "sh") && command[1] == "-c" {
+        return Ok(command.to_vec());
+    }
+
+    let has_operator_element = command
+        .iter()
+        .any(|e| SHELL_OPERATORS.contains(&e.as_str()));
+    let single_with_operator = command.len() == 1 && contains_operator_token(&command[0]);
+
+    if !(has_operator_element || single_with_operator) {
+        return Ok(command.to_vec());
+    }
+
+    // Collect which operators appear, for the error message.
+    let mut found_ops: Vec<&str> = command
+        .iter()
+        .filter_map(|e| SHELL_OPERATORS.iter().copied().find(|op| op == &e.as_str()))
+        .collect();
+    if found_ops.is_empty() && single_with_operator {
+        for tok in command[0].split_whitespace() {
+            if let Some(op) = SHELL_OPERATORS.iter().copied().find(|op| *op == tok) {
+                found_ops.push(op);
+            }
+        }
+    }
+    found_ops.sort();
+    found_ops.dedup();
+
+    if command.iter().any(|e| contains_tera_syntax(e)) {
+        return Err(HookCommandError::OperatorTemplateCollision {
+            operators: found_ops.join(", "),
+        });
+    }
+
+    let body = if single_with_operator {
+        command[0].clone()
+    } else {
+        command
+            .iter()
+            .map(|tok| {
+                if SHELL_OPERATORS.contains(&tok.as_str()) {
+                    tok.clone()
+                } else {
+                    posix_quote(tok)
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(" ")
+    };
+
+    Ok(vec!["bash".to_string(), "-c".to_string(), body])
+}
+
 #[derive(Serialize, Debug)]
 pub enum ConditionalError {
     InvalidContext(#[serde(skip)] tera::Error),
@@ -301,6 +420,24 @@ pub fn evaluate_hook_plan(
             Ok(true) => {}
         }
 
+        // Auto-wrap chained shell commands before templating. Detection is
+        // pre-template by design: a slot value rendering to `&&` must not
+        // silently become shell syntax.
+        let command_to_template = match normalize_hook_command_for_execution(&hook.command) {
+            Ok(normalized) => normalized,
+            Err(e) => {
+                results.push(HookPlanEntry {
+                    key: hook.key.clone(),
+                    command: hook.command.clone(),
+                    should_run: false,
+                    skip_reason: Some("template_error".to_string()),
+                    template_errors: vec![format!("hook '{}': {}", hook.key, e)],
+                });
+                // Do NOT flip hook_ran — collision is a hard plan-stage error.
+                continue;
+            }
+        };
+
         // Template the command args. Matches native semantics: templating
         // failure is a hard error — the hook is NOT runnable, and
         // hook_ran_* is NOT flipped (downstream conditionals see false).
@@ -309,7 +446,7 @@ pub fn evaluate_hook_plan(
             Err(e) => {
                 results.push(HookPlanEntry {
                     key: hook.key.clone(),
-                    command: hook.command.clone(),
+                    command: command_to_template,
                     should_run: false,
                     skip_reason: Some("template_error".to_string()),
                     template_errors: vec![format!("context error: {}", e)],
@@ -320,8 +457,7 @@ pub fn evaluate_hook_plan(
         };
 
         let mut template_errors = Vec::new();
-        let templated_command: Vec<String> = hook
-            .command
+        let templated_command: Vec<String> = command_to_template
             .iter()
             .map(|arg| match Tera::one_off(arg, &context, false) {
                 Ok(rendered) => rendered,
@@ -373,6 +509,8 @@ pub enum Error {
     InvalidConditional(Hook, ConditionalError),
     #[error("Setup failed: {0}")]
     SetupFailed(Hook, io::Error),
+    #[error("invalid hook command for '{key}': {source}", key = .0.key, source = .1)]
+    InvalidHookCommand(Hook, #[source] HookCommandError),
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -412,14 +550,18 @@ pub fn run_hooks_stream(
         }
     }
 
-    // Apply template to command
+    // Normalize chained shell commands BEFORE templating, then template.
+    // Auto-wrap detection is pre-template so a slot value rendering to `&&`
+    // cannot silently become shell syntax.
     let mut templated_hooks = Vec::new();
     for hook in queued_hooks {
+        let normalized = normalize_hook_command_for_execution(&hook.command)
+            .map_err(|e| Error::InvalidHookCommand(hook.clone(), e))?;
+
         let context = Context::from_serialize(data)
             .map_err(|e| Error::ErrorRenderingTemplate(hook.clone(), e))?;
 
-        let command = hook
-            .command
+        let command = normalized
             .iter()
             .map(|arg| {
                 Tera::one_off(arg, &context, false)
@@ -606,6 +748,9 @@ impl std::error::Error for ConfigError {}
 ///   - `if` conditional templates that fail to parse (unclosed brackets,
 ///     bad syntax)
 ///   - `command` arg templates that fail to parse
+///   - `command` argv shapes that combine shell operators with template
+///     expressions (auto-wrap unsafe — see
+///     [`normalize_hook_command_for_execution`])
 ///
 /// Returns every problem found, not just the first. The companion to
 /// `slot::validate`, used by the top-level `check` to produce structured
@@ -655,6 +800,18 @@ pub fn validate_config(hooks: &[Hook], slots: &[Slot]) -> Vec<ConfigError> {
                     code: Some("hook::command_template_parse"),
                 });
             }
+        }
+
+        // Auto-wrap collision is statically knowable — surface it at
+        // config-validation time so `spackle check` catches what
+        // `plan_hooks` / native execution would later refuse.
+        if let Err(e) = normalize_hook_command_for_execution(&hook.command) {
+            errors.push(ConfigError {
+                hook_key: hook.key.clone(),
+                message: e.to_string(),
+                span: None,
+                code: Some("hook::command_shell_injection_risk"),
+            });
         }
     }
 
@@ -1444,5 +1601,356 @@ mod tests {
                 assert!(plan[1].template_errors.is_empty());
             }
         }
+    }
+
+    // --- normalize_hook_command_for_execution ---
+
+    fn vs(args: &[&str]) -> Vec<String> {
+        args.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn normalize_hook_command_for_execution_table() {
+        struct Case {
+            name: &'static str,
+            input: Vec<String>,
+            expected: Result<Vec<String>, ()>, // Err(()) means "any HookCommandError"
+        }
+
+        let cases = vec![
+            Case {
+                name: "empty",
+                input: vec![],
+                expected: Ok(vec![]),
+            },
+            Case {
+                name: "no operators",
+                input: vs(&["echo", "hi"]),
+                expected: Ok(vs(&["echo", "hi"])),
+            },
+            Case {
+                name: "operator between args",
+                input: vs(&["git", "init", "&&", "git", "add", "."]),
+                expected: Ok(vs(&["bash", "-c", "git init && git add ."])),
+            },
+            Case {
+                name: "operator with quoted arg",
+                input: vs(&[
+                    "git",
+                    "commit",
+                    "-m",
+                    "initial commit",
+                    "&&",
+                    "git",
+                    "status",
+                ]),
+                expected: Ok(vs(&[
+                    "bash",
+                    "-c",
+                    "git commit -m 'initial commit' && git status",
+                ])),
+            },
+            Case {
+                name: "arg with single quote",
+                input: vs(&["echo", "it's", "&&", "true"]),
+                expected: Ok(vs(&["bash", "-c", "echo 'it'\\''s' && true"])),
+            },
+            Case {
+                name: "arg with $ stays literal via single-quote",
+                input: vs(&["echo", "$PATH", "&&", "echo", "done"]),
+                expected: Ok(vs(&["bash", "-c", "echo '$PATH' && echo done"])),
+            },
+            Case {
+                name: "pipe operator",
+                input: vs(&["cat", "f", "|", "wc", "-l"]),
+                expected: Ok(vs(&["bash", "-c", "cat f | wc -l"])),
+            },
+            Case {
+                name: "or operator",
+                input: vs(&["false", "||", "true"]),
+                expected: Ok(vs(&["bash", "-c", "false || true"])),
+            },
+            Case {
+                name: "semicolon operator",
+                input: vs(&["true", ";", "echo", "hi"]),
+                expected: Ok(vs(&["bash", "-c", "true ; echo hi"])),
+            },
+            Case {
+                name: "operator as substring NOT triggered",
+                input: vs(&["echo", "a&&b"]),
+                expected: Ok(vs(&["echo", "a&&b"])),
+            },
+            Case {
+                name: "already wrapped (bash)",
+                input: vs(&["bash", "-c", "x && y"]),
+                expected: Ok(vs(&["bash", "-c", "x && y"])),
+            },
+            Case {
+                name: "already wrapped (sh)",
+                input: vs(&["sh", "-c", "x && y"]),
+                expected: Ok(vs(&["sh", "-c", "x && y"])),
+            },
+            Case {
+                name: "single-element with operator tokens",
+                input: vs(&["git init && git add ."]),
+                expected: Ok(vs(&["bash", "-c", "git init && git add ."])),
+            },
+            Case {
+                name: "single-element no operator",
+                input: vs(&["echo hi"]),
+                expected: Ok(vs(&["echo hi"])),
+            },
+            Case {
+                name: "operator + {{ name }} → err",
+                input: vs(&["echo", "{{ name }}", "&&", "echo", "hi"]),
+                expected: Err(()),
+            },
+            Case {
+                name: "operator + {% if %} → err",
+                input: vs(&["{% if x %}echo a{% endif %}", "&&", "echo", "b"]),
+                expected: Err(()),
+            },
+            Case {
+                name: "operator + {# comment #} → err",
+                input: vs(&["echo", "{# c #}", "&&", "echo", "b"]),
+                expected: Err(()),
+            },
+            Case {
+                name: "template only, no operator → unchanged",
+                input: vs(&["echo", "{{ name }}"]),
+                expected: Ok(vs(&["echo", "{{ name }}"])),
+            },
+        ];
+
+        for c in cases {
+            let got = normalize_hook_command_for_execution(&c.input);
+            match (&c.expected, &got) {
+                (Ok(exp), Ok(actual)) => {
+                    assert_eq!(actual, exp, "case {}", c.name);
+                }
+                (Err(_), Err(_)) => {
+                    // any HookCommandError is fine; current enum has one variant
+                }
+                _ => panic!(
+                    "case {}: result mismatch — expected {:?}, got {:?}",
+                    c.name, c.expected, got
+                ),
+            }
+        }
+    }
+
+    #[test]
+    fn normalize_hook_command_idempotent() {
+        let cases = vec![
+            vs(&["git", "init", "&&", "git", "add", "."]),
+            vs(&[
+                "git",
+                "commit",
+                "-m",
+                "initial commit",
+                "&&",
+                "git",
+                "status",
+            ]),
+            vs(&["echo", "$PATH", "&&", "echo", "done"]),
+            vs(&["git init && git add ."]),
+        ];
+        for input in cases {
+            let once = normalize_hook_command_for_execution(&input).expect("first pass");
+            let twice = normalize_hook_command_for_execution(&once).expect("second pass");
+            assert_eq!(once, twice, "idempotency for {:?}", input);
+        }
+    }
+
+    #[test]
+    fn evaluate_hook_plan_auto_wrap_basic() {
+        let hooks = vec![Hook {
+            key: "chain".to_string(),
+            command: vs(&["git", "init", "&&", "git", "add", "."]),
+            default: Some(true),
+            ..Hook::default()
+        }];
+        let plan = evaluate_hook_plan(&hooks, &[], &HashMap::new());
+        assert_eq!(plan.len(), 1);
+        assert!(plan[0].should_run);
+        assert_eq!(
+            plan[0].command,
+            vs(&["bash", "-c", "git init && git add ."])
+        );
+        assert!(plan[0].template_errors.is_empty());
+    }
+
+    #[test]
+    fn evaluate_hook_plan_auto_wrap_collision_errors() {
+        let hooks = vec![
+            Hook {
+                key: "broken".to_string(),
+                command: vs(&["echo", "{{ name }}", "&&", "echo", "done"]),
+                default: Some(true),
+                ..Hook::default()
+            },
+            Hook {
+                key: "after".to_string(),
+                command: vs(&["echo", "after"]),
+                r#if: Some("{{ hook_ran_broken }}".to_string()),
+                default: Some(true),
+                ..Hook::default()
+            },
+        ];
+        let data = HashMap::from([("name".to_string(), "hi".to_string())]);
+        let plan = evaluate_hook_plan(&hooks, &[], &data);
+        assert_eq!(plan.len(), 2);
+        assert!(!plan[0].should_run);
+        assert_eq!(plan[0].skip_reason.as_deref(), Some("template_error"));
+        assert!(
+            plan[0].template_errors[0].contains("shell injection"),
+            "got {:?}",
+            plan[0].template_errors
+        );
+        // hook_ran_broken must remain false → downstream conditional fails
+        assert!(!plan[1].should_run);
+        assert_eq!(plan[1].skip_reason.as_deref(), Some("false_conditional"));
+    }
+
+    #[test]
+    fn evaluate_hook_plan_already_wrapped_passthrough() {
+        let hooks = vec![Hook {
+            key: "explicit".to_string(),
+            command: vs(&["bash", "-c", "echo {{ name }} && echo done"]),
+            default: Some(true),
+            ..Hook::default()
+        }];
+        let data = HashMap::from([("name".to_string(), "hi".to_string())]);
+        let plan = evaluate_hook_plan(&hooks, &[], &data);
+        assert!(plan[0].should_run);
+        // Templating still runs on the body, so {{ name }} → hi
+        assert_eq!(plan[0].command, vs(&["bash", "-c", "echo hi && echo done"]));
+    }
+
+    #[test]
+    fn run_hooks_stream_chained_command_executes() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let hooks = vec![Hook {
+            key: "chain".to_string(),
+            command: vs(&["touch", "a", "&&", "touch", "b"]),
+            ..Hook::default()
+        }];
+        let results = run_hooks(&hooks, tmp.path(), &Vec::new(), &HashMap::new(), None)
+            .expect("run_hooks failed");
+        assert!(
+            results.iter().any(|r| matches!(
+                r,
+                HookResult {
+                    kind: HookResultKind::Completed { .. },
+                    ..
+                }
+            )),
+            "expected chained command to complete, got {:?}",
+            results
+        );
+        assert!(tmp.path().join("a").exists(), "file 'a' not created");
+        assert!(tmp.path().join("b").exists(), "file 'b' not created");
+    }
+
+    #[test]
+    fn run_hooks_stream_chained_with_template_errors_invalid_command() {
+        let hooks = vec![Hook {
+            key: "broken".to_string(),
+            command: vs(&["touch", "{{ name }}/a", "&&", "touch", "{{ name }}/b"]),
+            ..Hook::default()
+        }];
+        let err = run_hooks(
+            &hooks,
+            ".",
+            &Vec::new(),
+            &HashMap::from([("name".to_string(), "x".to_string())]),
+            None,
+        )
+        .expect_err("expected InvalidHookCommand error");
+
+        // Display must include both the hook key and the source message
+        // so the CLI surfaces the actual collision reason.
+        let msg = err.to_string();
+        assert!(
+            msg.contains("'broken'"),
+            "expected hook key in msg, got: {}",
+            msg
+        );
+        assert!(
+            msg.contains("shell injection"),
+            "expected source error text in msg, got: {}",
+            msg
+        );
+
+        match err {
+            Error::InvalidHookCommand(_, HookCommandError::OperatorTemplateCollision { .. }) => {}
+            other => panic!("expected InvalidHookCommand, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn validate_config_flags_operator_template_collision() {
+        let hooks = vec![
+            Hook {
+                key: "broken".to_string(),
+                command: vs(&["echo", "{{ name }}", "&&", "echo", "done"]),
+                ..Hook::default()
+            },
+            Hook {
+                key: "fine".to_string(),
+                command: vs(&["echo", "hi"]),
+                ..Hook::default()
+            },
+            Hook {
+                key: "fine_chain".to_string(),
+                command: vs(&["touch", "a", "&&", "touch", "b"]),
+                ..Hook::default()
+            },
+        ];
+        let errors = validate_config(&hooks, &[]);
+
+        let collision: Vec<_> = errors
+            .iter()
+            .filter(|e| e.code == Some("hook::command_shell_injection_risk"))
+            .collect();
+        assert_eq!(
+            collision.len(),
+            1,
+            "expected exactly one collision diag, got {:#?}",
+            errors
+        );
+        assert_eq!(collision[0].hook_key, "broken");
+        assert!(
+            collision[0].message.contains("shell injection"),
+            "expected shell injection mention, got: {}",
+            collision[0].message
+        );
+    }
+
+    #[test]
+    fn run_hooks_stream_explicit_bash_with_template_runs() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let hooks = vec![Hook {
+            key: "explicit".to_string(),
+            command: vs(&["bash", "-c", "touch {{ name }} && touch other"]),
+            ..Hook::default()
+        }];
+        let results = run_hooks(
+            &hooks,
+            tmp.path(),
+            &Vec::new(),
+            &HashMap::from([("name".to_string(), "first".to_string())]),
+            None,
+        )
+        .expect("run_hooks failed");
+        assert!(results.iter().all(|r| matches!(
+            r,
+            HookResult {
+                kind: HookResultKind::Completed { .. },
+                ..
+            }
+        )));
+        assert!(tmp.path().join("first").exists());
+        assert!(tmp.path().join("other").exists());
     }
 }

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -20,10 +20,72 @@ use users::User;
 
 use crate::needs::{is_satisfied, Needy};
 
+/// A hook's command, as written in `spackle.toml`. Two forms:
+///
+/// - `command = "echo {{ name }} && echo hi"` — a single string. Templated
+///   as a whole, then run via `bash -c`. Slot values substitute as **raw
+///   shell text**; the author owns quoting (`'{{ name }}'` for literal).
+/// - `command = ["echo", "{{ name }}", "&&", "echo", "hi"]` — an argv
+///   array. Each element is templated, then POSIX-quoted (bare shell
+///   operators pass through), then joined and run via `bash -c`. Slot
+///   values are **literal arguments** and can't act as shell syntax.
+///
+/// An array of the shape `["bash"|"sh", "-c", body]` is a pass-through:
+/// `body` is templated and re-wrapped, equivalent to the string form.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum HookCommand {
+    String(String),
+    Array(Vec<String>),
+}
+
+impl HookCommand {
+    /// Template-bearing parts, for parse-only validation.
+    fn template_parts(&self) -> Vec<&str> {
+        match self {
+            HookCommand::String(s) => vec![s.as_str()],
+            HookCommand::Array(args) => args.iter().map(|s| s.as_str()).collect(),
+        }
+    }
+
+    /// Un-templated shell body, for the static denylist scan and `Display`.
+    /// Mirrors [`render_command`]'s quoting (just without templating) so the
+    /// static scan matches what would actually execute: array elements are
+    /// POSIX-quoted (operators pass through), which keeps a literal argument
+    /// like `["echo", "a; rm -rf /"]` from looking like a chained command.
+    fn raw_body(&self) -> String {
+        match self {
+            HookCommand::String(s) => s.clone(),
+            HookCommand::Array(args) if is_shell_wrapper(args) => args[2].clone(),
+            HookCommand::Array(args) => args
+                .iter()
+                .map(|a| {
+                    if SHELL_OPERATORS.contains(&a.as_str()) {
+                        a.clone()
+                    } else {
+                        posix_quote(a)
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join(" "),
+        }
+    }
+
+    /// Argv to surface in a plan entry for a hook that will NOT run. Runnable
+    /// hooks carry their rendered `["bash", "-c", body]`; this is only for
+    /// skipped/errored entries where no body was rendered.
+    pub fn display_argv(&self) -> Vec<String> {
+        match self {
+            HookCommand::String(s) => vec!["bash".to_string(), "-c".to_string(), s.clone()],
+            HookCommand::Array(args) => args.clone(),
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Hook {
     pub key: String,
-    pub command: Vec<String>,
+    pub command: HookCommand,
     pub r#if: Option<String>,
     #[serde(default)]
     pub needs: Vec<String>,
@@ -47,12 +109,7 @@ impl Display for Hook {
                 "".to_string()
             }
             .dimmed(),
-            self.command
-                .iter()
-                .map(|s| s.to_string())
-                .collect::<Vec<String>>()
-                .join(" ")
-                .dimmed()
+            self.command.raw_body().dimmed()
         )
     }
 }
@@ -61,7 +118,7 @@ impl Default for Hook {
     fn default() -> Self {
         Hook {
             key: "".to_string(),
-            command: vec![],
+            command: HookCommand::Array(vec![]),
             r#if: None,
             needs: vec![],
             name: None,
@@ -120,14 +177,16 @@ const SHELL_OPERATORS: &[&str] = &["&&", "||", "|", ";"];
 
 #[derive(Debug, thiserror::Error)]
 pub enum HookCommandError {
-    #[error(
-        "shell operators ({operators}) combined with template syntax in command elements: \
-         auto-wrap is unsafe (shell injection risk via slot values). \
-         Use explicit command = [\"bash\", \"-c\", \"...\"] and quote templated values yourself."
-    )]
-    OperatorTemplateCollision { operators: String },
+    #[error("command matches a blocked dangerous pattern ({pattern}); refusing to run: {matched}")]
+    DangerousPattern {
+        pattern: &'static str,
+        matched: String,
+    },
 }
 
+/// POSIX single-quote a string so it survives `bash -c` as one literal
+/// argument. Safe characters pass through unquoted; everything else is
+/// wrapped in `'...'` with embedded single quotes escaped as `'\''`.
 fn posix_quote(s: &str) -> String {
     if s.is_empty() {
         return "''".to_string();
@@ -151,88 +210,197 @@ fn posix_quote(s: &str) -> String {
     out
 }
 
-fn contains_operator_token(s: &str) -> bool {
-    s.split_whitespace()
-        .any(|tok| SHELL_OPERATORS.contains(&tok))
+fn is_shell_wrapper(args: &[String]) -> bool {
+    args.len() >= 3 && (args[0] == "bash" || args[0] == "sh") && args[1] == "-c"
 }
 
-fn contains_tera_syntax(s: &str) -> bool {
-    s.contains("{{") || s.contains("{%") || s.contains("{#")
+/// Render a [`HookCommand`] into the full argv to spawn — always
+/// `["bash", "-c", <body>, <positional>...]`. The executable shell text is
+/// always at index 2, which is what [`dangerous_pattern_check`] must scan.
+///
+/// - String form: template the whole string (raw substitution).
+/// - `["bash"|"sh", "-c", body, pos...]`: template `body` and any positional
+///   args (pass-through). The `-c` body is taken verbatim so the denylist
+///   sees the real command, not a quoted-inside-out version of it.
+/// - Array form: template each element, then POSIX-quote (bare shell
+///   operators pass through), then join into a single body. This
+///   template-then-quote order makes slot values literal arguments — they
+///   can't act as shell syntax.
+pub fn render_command(
+    command: &HookCommand,
+    context: &Context,
+) -> Result<Vec<String>, tera::Error> {
+    let mut argv = vec!["bash".to_string(), "-c".to_string()];
+    match command {
+        HookCommand::String(s) => {
+            argv.push(Tera::one_off(s, context, false)?);
+        }
+        HookCommand::Array(args) if is_shell_wrapper(args) => {
+            // args[2] is the `-c` body; args[3..] are bash positional params
+            // ($0, $1, ...). Render each and forward them as real argv so the
+            // body executes as the author wrote it.
+            for arg in &args[2..] {
+                argv.push(Tera::one_off(arg, context, false)?);
+            }
+        }
+        HookCommand::Array(args) => {
+            let mut parts = Vec::with_capacity(args.len());
+            for arg in args {
+                if SHELL_OPERATORS.contains(&arg.as_str()) {
+                    parts.push(arg.clone());
+                } else {
+                    parts.push(posix_quote(&Tera::one_off(arg, context, false)?));
+                }
+            }
+            argv.push(parts.join(" "));
+        }
+    }
+    Ok(argv)
 }
 
-/// Normalize a hook command for execution.
-///
-/// - Returns the input unchanged when no shell operators are present, or
-///   when the command is already wrapped (`["bash"|"sh", "-c", ...]`).
-/// - When any element is exactly `&&`, `||`, `|`, or `;` (OR the command
-///   is a single-element vec whose lone string contains an operator
-///   token as a whitespace-bounded word), rewrites the command to
-///   `["bash", "-c", "<POSIX-quoted body>"]`.
-/// - Errors when wrap would trigger AND any element contains Tera
-///   syntax (`{{`, `{%`, `{#`) — the author must use explicit
-///   `["bash", "-c", "..."]` so they own shell-safety of substituted
-///   values.
-///
-/// Idempotent — safe to call from both the planner and the executor.
-pub fn normalize_hook_command_for_execution(
-    command: &[String],
-) -> Result<Vec<String>, HookCommandError> {
-    if command.is_empty() {
-        return Ok(command.to_vec());
+/// Refuse a small denylist of catastrophic shell patterns in a rendered
+/// command body. This is the only safety net: hooks run as the target user,
+/// so the blast radius is what that user could already type at their shell —
+/// but a templated `rm -rf /` or fork bomb is almost never intended, so we
+/// block the unambiguous cases.
+pub fn dangerous_pattern_check(rendered: &str) -> Result<(), HookCommandError> {
+    let collapsed: String = rendered.chars().filter(|c| !c.is_whitespace()).collect();
+    if collapsed.contains(":(){:|:&};:") {
+        return Err(HookCommandError::DangerousPattern {
+            pattern: "fork bomb",
+            matched: rendered.trim().to_string(),
+        });
     }
-
-    // Already-wrapped guard: `["bash"|"sh", "-c", ...]`.
-    if command.len() >= 2 && (command[0] == "bash" || command[0] == "sh") && command[1] == "-c" {
-        return Ok(command.to_vec());
+    if let Some(matched) = detect_rm_rf_root(rendered) {
+        return Err(HookCommandError::DangerousPattern {
+            pattern: "recursive force-remove of a root/system path",
+            matched,
+        });
     }
+    Ok(())
+}
 
-    let has_operator_element = command
-        .iter()
-        .any(|e| SHELL_OPERATORS.contains(&e.as_str()));
-    let single_with_operator = command.len() == 1 && contains_operator_token(&command[0]);
-
-    if !(has_operator_element || single_with_operator) {
-        return Ok(command.to_vec());
+/// True for targets that a `rm -rf` should never touch: `/`, `/*`, or a
+/// top-level system directory (with optional trailing `/` or `/*`).
+fn is_dangerous_rm_target(target: &str) -> bool {
+    let core = target.trim_end_matches("/*").trim_end_matches('/');
+    if core.is_empty() {
+        return true; // "/", "//", "/*"
     }
+    const TOP_LEVEL: &[&str] = &[
+        "/bin", "/boot", "/dev", "/etc", "/home", "/lib", "/lib64", "/proc", "/root", "/sbin",
+        "/sys", "/usr", "/var",
+    ];
+    TOP_LEVEL.contains(&core)
+}
 
-    // Collect which operators appear, for the error message.
-    let mut found_ops: Vec<&str> = command
-        .iter()
-        .filter_map(|e| SHELL_OPERATORS.iter().copied().find(|op| op == &e.as_str()))
-        .collect();
-    if found_ops.is_empty() && single_with_operator {
-        for tok in command[0].split_whitespace() {
-            if let Some(op) = SHELL_OPERATORS.iter().copied().find(|op| *op == tok) {
-                found_ops.push(op);
+/// Is this `rm` segment recursive AND forced AND aimed at a root/system path?
+fn rm_segment_is_dangerous(segment: &[&str]) -> bool {
+    let (mut recursive, mut force, mut root_target) = (false, false, false);
+    for arg in segment {
+        if let Some(long) = arg.strip_prefix("--") {
+            match long {
+                "recursive" => recursive = true,
+                "force" => force = true,
+                _ => {}
+            }
+        } else if let Some(short) = arg.strip_prefix('-') {
+            if short.contains(['r', 'R']) {
+                recursive = true;
+            }
+            if short.contains('f') {
+                force = true;
+            }
+        } else if is_dangerous_rm_target(arg) {
+            root_target = true;
+        }
+    }
+    recursive && force && root_target
+}
+
+/// Split a shell body into command segments at *unquoted* command separators
+/// (`;`, `&`, `&&`, `|`, `||`, newline). Single and double quotes — and
+/// backslash escapes outside single quotes — suppress separator recognition,
+/// so a separator inside a quoted argument stays part of one segment. This is
+/// a best-effort scanner for the denylist, not a full shell parser, but it
+/// matches separators whether or not they are whitespace-padded
+/// (`a;rm`, `a && rm`, a trailing newline, …).
+fn split_command_segments(body: &str) -> Vec<String> {
+    let mut segments = Vec::new();
+    let mut current = String::new();
+    let mut chars = body.chars().peekable();
+    let mut in_single = false;
+    let mut in_double = false;
+
+    while let Some(c) = chars.next() {
+        if in_single {
+            current.push(c);
+            if c == '\'' {
+                in_single = false;
+            }
+            continue;
+        }
+        if in_double {
+            current.push(c);
+            if c == '\\' {
+                if let Some(n) = chars.next() {
+                    current.push(n);
+                }
+            } else if c == '"' {
+                in_double = false;
+            }
+            continue;
+        }
+        match c {
+            '\'' => {
+                in_single = true;
+                current.push(c);
+            }
+            '"' => {
+                in_double = true;
+                current.push(c);
+            }
+            '\\' => {
+                current.push(c);
+                if let Some(n) = chars.next() {
+                    current.push(n);
+                }
+            }
+            ';' | '\n' | '&' | '|' => {
+                // Consume a doubled operator (`&&` / `||`) as one separator.
+                if (c == '&' || c == '|') && chars.peek() == Some(&c) {
+                    chars.next();
+                }
+                segments.push(std::mem::take(&mut current));
+            }
+            _ => current.push(c),
+        }
+    }
+    segments.push(current);
+    segments
+}
+
+/// Scan a rendered command body for a recursive, forced `rm` of a
+/// root/system path. Splits into command segments so chained commands are
+/// considered independently, then for each segment checks whether the leading
+/// command — after transparent `sudo`/`doas` — is such an `rm`. Quoted
+/// separators don't split, so a literal argument like `echo 'a; rm -rf /'` is
+/// correctly treated as data, while `echo a; rm -rf /` is caught.
+fn detect_rm_rf_root(rendered: &str) -> Option<String> {
+    for segment in split_command_segments(rendered) {
+        let tokens: Vec<&str> = segment.split_whitespace().collect();
+        let mut idx = 0;
+        while matches!(tokens.get(idx), Some(&"sudo") | Some(&"doas")) {
+            idx += 1;
+        }
+        if tokens.get(idx) == Some(&"rm") {
+            let args = &tokens[idx + 1..];
+            if rm_segment_is_dangerous(args) {
+                return Some(format!("rm {}", args.join(" ")));
             }
         }
     }
-    found_ops.sort();
-    found_ops.dedup();
-
-    if command.iter().any(|e| contains_tera_syntax(e)) {
-        return Err(HookCommandError::OperatorTemplateCollision {
-            operators: found_ops.join(", "),
-        });
-    }
-
-    let body = if single_with_operator {
-        command[0].clone()
-    } else {
-        command
-            .iter()
-            .map(|tok| {
-                if SHELL_OPERATORS.contains(&tok.as_str()) {
-                    tok.clone()
-                } else {
-                    posix_quote(tok)
-                }
-            })
-            .collect::<Vec<_>>()
-            .join(" ")
-    };
-
-    Ok(vec!["bash".to_string(), "-c".to_string(), body])
+    None
 }
 
 #[derive(Serialize, Debug)]
@@ -375,7 +543,7 @@ pub fn evaluate_hook_plan(
         if !hook.is_enabled(&running_data) {
             results.push(HookPlanEntry {
                 key: hook.key.clone(),
-                command: hook.command.clone(),
+                command: hook.command.display_argv(),
                 should_run: false,
                 skip_reason: Some("user_disabled".to_string()),
                 template_errors: vec![],
@@ -386,7 +554,7 @@ pub fn evaluate_hook_plan(
         if !hook.is_satisfied(&items, &running_data) {
             results.push(HookPlanEntry {
                 key: hook.key.clone(),
-                command: hook.command.clone(),
+                command: hook.command.display_argv(),
                 should_run: false,
                 skip_reason: Some("unsatisfied_needs".to_string()),
                 template_errors: vec![],
@@ -400,7 +568,7 @@ pub fn evaluate_hook_plan(
             Ok(false) => {
                 results.push(HookPlanEntry {
                     key: hook.key.clone(),
-                    command: hook.command.clone(),
+                    command: hook.command.display_argv(),
                     should_run: false,
                     skip_reason: Some("false_conditional".to_string()),
                     template_errors: vec![],
@@ -410,7 +578,7 @@ pub fn evaluate_hook_plan(
             Err(e) => {
                 results.push(HookPlanEntry {
                     key: hook.key.clone(),
-                    command: hook.command.clone(),
+                    command: hook.command.display_argv(),
                     should_run: false,
                     skip_reason: Some(format!("conditional_error: {}", e)),
                     template_errors: vec![],
@@ -420,72 +588,55 @@ pub fn evaluate_hook_plan(
             Ok(true) => {}
         }
 
-        // Auto-wrap chained shell commands before templating. Detection is
-        // pre-template by design: a slot value rendering to `&&` must not
-        // silently become shell syntax.
-        let command_to_template = match normalize_hook_command_for_execution(&hook.command) {
-            Ok(normalized) => normalized,
-            Err(e) => {
-                results.push(HookPlanEntry {
-                    key: hook.key.clone(),
-                    command: hook.command.clone(),
-                    should_run: false,
-                    skip_reason: Some("template_error".to_string()),
-                    template_errors: vec![format!("hook '{}': {}", hook.key, e)],
-                });
-                // Do NOT flip hook_ran — collision is a hard plan-stage error.
-                continue;
-            }
-        };
-
-        // Template the command args. Matches native semantics: templating
-        // failure is a hard error — the hook is NOT runnable, and
-        // hook_ran_* is NOT flipped (downstream conditionals see false).
+        // Template the command into its `bash -c` body. Matches native
+        // semantics: templating failure is a hard error — the hook is NOT
+        // runnable, and hook_ran_* is NOT flipped (downstream conditionals
+        // see false).
         let context = match Context::from_serialize(&running_data) {
             Ok(c) => c,
             Err(e) => {
                 results.push(HookPlanEntry {
                     key: hook.key.clone(),
-                    command: command_to_template,
+                    command: hook.command.display_argv(),
                     should_run: false,
                     skip_reason: Some("template_error".to_string()),
                     template_errors: vec![format!("context error: {}", e)],
                 });
-                // Do NOT flip hook_ran — native would have aborted here.
                 continue;
             }
         };
 
-        let mut template_errors = Vec::new();
-        let templated_command: Vec<String> = command_to_template
-            .iter()
-            .map(|arg| match Tera::one_off(arg, &context, false) {
-                Ok(rendered) => rendered,
-                Err(e) => {
-                    template_errors.push(format!("arg {:?}: {}", arg, e));
-                    arg.clone()
-                }
-            })
-            .collect();
+        let argv = match render_command(&hook.command, &context) {
+            Ok(argv) => argv,
+            Err(e) => {
+                results.push(HookPlanEntry {
+                    key: hook.key.clone(),
+                    command: hook.command.display_argv(),
+                    should_run: false,
+                    skip_reason: Some("template_error".to_string()),
+                    template_errors: vec![format!("hook '{}': {}", hook.key, e)],
+                });
+                continue;
+            }
+        };
 
-        if !template_errors.is_empty() {
-            // Native run_hooks_stream returns Error::ErrorRenderingTemplate
-            // and aborts the entire stream. We surface the same signal as
-            // should_run=false so the caller can decide.
+        // Refuse catastrophic patterns in the rendered `-c` body (argv[2]).
+        // Treated like a template error: the hook does not run and hook_ran_*
+        // stays false.
+        if let Err(e) = dangerous_pattern_check(&argv[2]) {
             results.push(HookPlanEntry {
                 key: hook.key.clone(),
-                command: templated_command,
+                command: argv,
                 should_run: false,
                 skip_reason: Some("template_error".to_string()),
-                template_errors,
+                template_errors: vec![format!("hook '{}': {}", hook.key, e)],
             });
-            // Do NOT flip hook_ran — native would have aborted here.
             continue;
         }
 
         results.push(HookPlanEntry {
             key: hook.key.clone(),
-            command: templated_command,
+            command: argv,
             should_run: true,
             skip_reason: None,
             template_errors: vec![],
@@ -550,36 +701,25 @@ pub fn run_hooks_stream(
         }
     }
 
-    // Normalize chained shell commands BEFORE templating, then template.
-    // Auto-wrap detection is pre-template so a slot value rendering to `&&`
-    // cannot silently become shell syntax.
-    let mut templated_hooks = Vec::new();
+    // Render each queued hook into its full `bash -c` argv, then build the
+    // command to run it. Rendering happens here (with the initial slot data);
+    // chained conditionals are re-evaluated in-stream against accumulated
+    // hook_ran_* state.
+    let mut commands = Vec::new();
     for hook in queued_hooks {
-        let normalized = normalize_hook_command_for_execution(&hook.command)
-            .map_err(|e| Error::InvalidHookCommand(hook.clone(), e))?;
-
         let context = Context::from_serialize(data)
             .map_err(|e| Error::ErrorRenderingTemplate(hook.clone(), e))?;
 
-        let command = normalized
-            .iter()
-            .map(|arg| {
-                Tera::one_off(arg, &context, false)
-                    .map_err(|e| Error::ErrorRenderingTemplate(hook.clone(), e))
-            })
-            .collect::<Result<Vec<String>, Error>>()?;
+        let argv = render_command(&hook.command, &context)
+            .map_err(|e| Error::ErrorRenderingTemplate(hook.clone(), e))?;
 
-        templated_hooks.push(Hook {
-            command,
-            ..hook.clone()
-        });
-    }
+        // argv[2] is the executable `-c` body — the thing the shell runs.
+        dangerous_pattern_check(&argv[2])
+            .map_err(|e| Error::InvalidHookCommand(hook.clone(), e))?;
 
-    let mut commands = Vec::new();
-    for hook in templated_hooks {
         let cmd = match run_as_user {
             // TODO spackle shouldn't need to depend on polyjuice, it should instead be able to receive an arbitrary Command from a consumer, who may choose to wrap it in polyjuice or not
-            Some(ref user) => match polyjuice::cmd_as_user(&hook.command[0], user.clone()) {
+            Some(ref user) => match polyjuice::cmd_as_user(&argv[0], user.clone()) {
                 Ok(cmd) => cmd,
                 Err(e) => {
                     return Err(Error::SetupFailed(
@@ -591,10 +731,10 @@ pub fn run_hooks_stream(
                     )); //TODO we probably want a different error type here
                 }
             },
-            None => process::Command::new(&hook.command[0]),
+            None => process::Command::new(&argv[0]),
         };
 
-        commands.push((hook, async_process::Command::from(cmd)));
+        commands.push((hook, argv, async_process::Command::from(cmd)));
     }
 
     let slot_data_owned = data.clone();
@@ -610,7 +750,7 @@ pub fn run_hooks_stream(
         }
 
         let mut ran_hooks = Vec::new();
-        for (hook, mut cmd) in commands {
+        for (hook, argv, mut cmd) in commands {
             yield HookStreamResult::HookStarted(hook.key.clone());
 
             // Evaluate conditional
@@ -643,7 +783,7 @@ pub fn run_hooks_stream(
                 continue;
             }
 
-            let cmd_result = cmd.args(&hook.command[1..])
+            let cmd_result = cmd.args(&argv[1..])
                 .current_dir(dir.as_ref())
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped())
@@ -747,10 +887,9 @@ impl std::error::Error for ConfigError {}
 ///   - `needs` references that don't resolve to a known slot or hook key
 ///   - `if` conditional templates that fail to parse (unclosed brackets,
 ///     bad syntax)
-///   - `command` arg templates that fail to parse
-///   - `command` argv shapes that combine shell operators with template
-///     expressions (auto-wrap unsafe — see
-///     [`normalize_hook_command_for_execution`])
+///   - `command` part templates that fail to parse
+///   - `command` bodies that match a blocked dangerous pattern (see
+///     [`dangerous_pattern_check`])
 ///
 /// Returns every problem found, not just the first. The companion to
 /// `slot::validate`, used by the top-level `check` to produce structured
@@ -788,29 +927,29 @@ pub fn validate_config(hooks: &[Hook], slots: &[Slot]) -> Vec<ConfigError> {
             }
         }
 
-        // Parse each command arg's template. Parse-only catches unclosed
+        // Parse each command part's template. Parse-only catches unclosed
         // brackets / bad filter syntax without needing slot values.
-        for (i, arg) in hook.command.iter().enumerate() {
-            if let Err(e) = tera::Tera::default().add_raw_template("__hook_cmd__", arg) {
+        for (i, part) in hook.command.template_parts().iter().enumerate() {
+            if let Err(e) = tera::Tera::default().add_raw_template("__hook_cmd__", part) {
                 let span = crate::diagnostic::extract_tera_span(&e);
                 errors.push(ConfigError {
                     hook_key: hook.key.clone(),
-                    message: format!("invalid command arg[{}] template: {}", i, e),
+                    message: format!("invalid command part[{}] template: {}", i, e),
                     span,
                     code: Some("hook::command_template_parse"),
                 });
             }
         }
 
-        // Auto-wrap collision is statically knowable — surface it at
-        // config-validation time so `spackle check` catches what
-        // `plan_hooks` / native execution would later refuse.
-        if let Err(e) = normalize_hook_command_for_execution(&hook.command) {
+        // Catch catastrophic patterns the author wrote literally. Slot-injected
+        // dangers are caught post-template at plan/exec time; this is the
+        // best-effort static check `spackle check` can do without slot data.
+        if let Err(e) = dangerous_pattern_check(&hook.command.raw_body()) {
             errors.push(ConfigError {
                 hook_key: hook.key.clone(),
                 message: e.to_string(),
                 span: None,
-                code: Some("hook::command_shell_injection_risk"),
+                code: Some("hook::command_dangerous_pattern"),
             });
         }
     }
@@ -860,7 +999,7 @@ mod tests {
     fn basic() {
         let hooks = vec![Hook {
             key: "hello world".to_string(),
-            command: vec!["echo".to_string(), "hello world".to_string()],
+            command: HookCommand::Array(vec!["echo".to_string(), "hello world".to_string()]),
             ..Hook::default()
         }];
 
@@ -873,7 +1012,7 @@ mod tests {
             // Hook::new("okay".to_string(), vec!["true".to_string()]),
             Hook {
                 key: "error".to_string(),
-                command: vec!["false".to_string()],
+                command: HookCommand::Array(vec!["false".to_string()]),
                 ..Hook::default()
             },
         ];
@@ -897,12 +1036,12 @@ mod tests {
         let hooks = vec![
             Hook {
                 key: "1".to_string(),
-                command: vec!["echo".to_string(), "hello world".to_string()],
+                command: HookCommand::Array(vec!["echo".to_string(), "hello world".to_string()]),
                 ..Hook::default()
             },
             Hook {
                 key: "2".to_string(),
-                command: vec!["invalid_cmd".to_string()],
+                command: HookCommand::Array(vec!["invalid_cmd".to_string()]),
                 ..Hook::default()
             },
         ];
@@ -928,24 +1067,24 @@ mod tests {
         let hooks = vec![
             Hook {
                 key: "1".to_string(),
-                command: vec!["echo".to_string(), "hello world".to_string()],
+                command: HookCommand::Array(vec!["echo".to_string(), "hello world".to_string()]),
                 r#if: Some("true".to_string()),
                 ..Hook::default()
             },
             Hook {
                 key: "2".to_string(),
-                command: vec!["echo".to_string(), "hello world".to_string()],
+                command: HookCommand::Array(vec!["echo".to_string(), "hello world".to_string()]),
                 r#if: Some("false".to_string()),
                 ..Hook::default()
             },
             Hook {
                 key: "3".to_string(),
-                command: vec!["echo".to_string(), "hello world".to_string()],
+                command: HookCommand::Array(vec!["echo".to_string(), "hello world".to_string()]),
                 ..Hook::default()
             },
             Hook {
                 key: "4".to_string(),
-                command: vec!["echo".to_string(), "hello world".to_string()],
+                command: HookCommand::Array(vec!["echo".to_string(), "hello world".to_string()]),
                 r#if: Some("{{ hook_ran_1 }}".to_string()),
                 ..Hook::default()
             },
@@ -984,13 +1123,13 @@ mod tests {
         let hooks = vec![
             Hook {
                 key: "1".to_string(),
-                command: vec!["echo".to_string(), "hello world".to_string()],
+                command: HookCommand::Array(vec!["echo".to_string(), "hello world".to_string()]),
                 r#if: Some("{{ good_var }}".to_string()),
                 ..Hook::default()
             },
             Hook {
                 key: "2".to_string(),
-                command: vec!["echo".to_string(), "hello world".to_string()],
+                command: HookCommand::Array(vec!["echo".to_string(), "hello world".to_string()]),
                 r#if: Some("{{ bad_var }}".to_string()),
                 ..Hook::default()
             },
@@ -1022,7 +1161,7 @@ mod tests {
     fn bad_conditional_value() {
         let hooks = vec![Hook {
             key: "1".to_string(),
-            command: vec!["echo".to_string(), "hello world".to_string()],
+            command: HookCommand::Array(vec!["echo".to_string(), "hello world".to_string()]),
             r#if: Some("lorem ipsum".to_string()),
             ..Hook::default()
         }];
@@ -1048,18 +1187,18 @@ mod tests {
         let hooks = vec![
             Hook {
                 key: "1".to_string(),
-                command: vec!["echo".to_string(), "hello world".to_string()],
+                command: HookCommand::Array(vec!["echo".to_string(), "hello world".to_string()]),
                 ..Hook::default()
             },
             Hook {
                 key: "2".to_string(),
-                command: vec!["echo".to_string(), "hello world".to_string()],
+                command: HookCommand::Array(vec!["echo".to_string(), "hello world".to_string()]),
                 default: Some(false),
                 ..Hook::default()
             },
             Hook {
                 key: "3".to_string(),
-                command: vec!["echo".to_string(), "hello world".to_string()],
+                command: HookCommand::Array(vec!["echo".to_string(), "hello world".to_string()]),
                 default: Some(false),
                 ..Hook::default()
             },
@@ -1105,12 +1244,18 @@ mod tests {
         let hooks = vec![
             Hook {
                 key: "1".to_string(),
-                command: vec!["{{ field_1 }}".to_string(), "{{ field_2 }}".to_string()],
+                command: HookCommand::Array(vec![
+                    "{{ field_1 }}".to_string(),
+                    "{{ field_2 }}".to_string(),
+                ]),
                 ..Hook::default()
             },
             Hook {
                 key: "2".to_string(),
-                command: vec!["echo".to_string(), "{{ _output_name }}".to_string()],
+                command: HookCommand::Array(vec![
+                    "echo".to_string(),
+                    "{{ _output_name }}".to_string(),
+                ]),
                 ..Hook::default()
             },
         ];
@@ -1158,7 +1303,10 @@ mod tests {
     fn invalid_templated_cmd() {
         let hooks = vec![Hook {
             key: "1".to_string(),
-            command: vec!["{{ field_1 }}".to_string(), "{{ field_2 }}".to_string()],
+            command: HookCommand::Array(vec![
+                "{{ field_1 }}".to_string(),
+                "{{ field_2 }}".to_string(),
+            ]),
             ..Hook::default()
         }];
 
@@ -1182,12 +1330,12 @@ mod tests {
         let hooks = vec![
             Hook {
                 key: "hook".to_string(),
-                command: vec!["true".to_string()],
+                command: HookCommand::Array(vec!["true".to_string()]),
                 ..Hook::default()
             },
             Hook {
                 key: "needy".to_string(),
-                command: vec!["true".to_string()],
+                command: HookCommand::Array(vec!["true".to_string()]),
                 needs: vec![
                     "hook".to_string(),
                     "string_slot".to_string(),
@@ -1243,13 +1391,13 @@ mod tests {
         let hooks = vec![
             Hook {
                 key: "hook".to_string(),
-                command: vec!["true".to_string()],
+                command: HookCommand::Array(vec!["true".to_string()]),
                 default: Some(false),
                 ..Hook::default()
             },
             Hook {
                 key: "needy".to_string(),
-                command: vec!["true".to_string()],
+                command: HookCommand::Array(vec!["true".to_string()]),
                 needs: vec!["hook".to_string()],
                 ..Hook::default()
             },
@@ -1273,7 +1421,7 @@ mod tests {
     fn needs_invalid_key() {
         let hooks = vec![Hook {
             key: "hook".to_string(),
-            command: vec!["true".to_string()],
+            command: HookCommand::Array(vec!["true".to_string()]),
             needs: vec!["invalid_key".to_string()],
             ..Hook::default()
         }];
@@ -1297,18 +1445,18 @@ mod tests {
         let hooks = vec![
             Hook {
                 key: "a".to_string(),
-                command: vec!["echo".to_string(), "a".to_string()],
+                command: HookCommand::Array(vec!["echo".to_string(), "a".to_string()]),
                 ..Hook::default()
             },
             Hook {
                 key: "b".to_string(),
-                command: vec!["echo".to_string(), "b".to_string()],
+                command: HookCommand::Array(vec!["echo".to_string(), "b".to_string()]),
                 needs: vec!["a".to_string()],
                 ..Hook::default()
             },
             Hook {
                 key: "c".to_string(),
-                command: vec!["echo".to_string(), "c".to_string()],
+                command: HookCommand::Array(vec!["echo".to_string(), "c".to_string()]),
                 needs: vec!["b".to_string()],
                 ..Hook::default()
             },
@@ -1335,14 +1483,14 @@ mod tests {
         let hooks = vec![
             Hook {
                 key: "hook_a".to_string(),
-                command: vec!["true".to_string()],
+                command: HookCommand::Array(vec!["true".to_string()]),
                 default: Some(false),
                 needs: vec!["slot_a".to_string()],
                 ..Hook::default()
             },
             Hook {
                 key: "hook_b".to_string(),
-                command: vec!["true".to_string()],
+                command: HookCommand::Array(vec!["true".to_string()]),
                 needs: vec!["hook_a".to_string()],
                 ..Hook::default()
             },
@@ -1410,7 +1558,7 @@ mod tests {
                 name: "default=true → runs",
                 hooks: vec![Hook {
                     key: "h1".to_string(),
-                    command: vec!["echo".to_string(), "hi".to_string()],
+                    command: HookCommand::Array(vec!["echo".to_string(), "hi".to_string()]),
                     default: Some(true),
                     ..Default::default()
                 }],
@@ -1422,7 +1570,7 @@ mod tests {
                 name: "default=false → user_disabled",
                 hooks: vec![Hook {
                     key: "h1".to_string(),
-                    command: vec!["echo".to_string()],
+                    command: HookCommand::Array(vec!["echo".to_string()]),
                     default: Some(false),
                     ..Default::default()
                 }],
@@ -1434,7 +1582,7 @@ mod tests {
                 name: "user override enables disabled hook",
                 hooks: vec![Hook {
                     key: "h1".to_string(),
-                    command: vec!["echo".to_string()],
+                    command: HookCommand::Array(vec!["echo".to_string()]),
                     default: Some(false),
                     ..Default::default()
                 }],
@@ -1447,13 +1595,13 @@ mod tests {
                 hooks: vec![
                     Hook {
                         key: "first".to_string(),
-                        command: vec!["echo".to_string(), "1".to_string()],
+                        command: HookCommand::Array(vec!["echo".to_string(), "1".to_string()]),
                         default: Some(true),
                         ..Default::default()
                     },
                     Hook {
                         key: "second".to_string(),
-                        command: vec!["echo".to_string(), "2".to_string()],
+                        command: HookCommand::Array(vec!["echo".to_string(), "2".to_string()]),
                         r#if: Some("{{ hook_ran_first }}".to_string()),
                         default: Some(true),
                         ..Default::default()
@@ -1468,13 +1616,13 @@ mod tests {
                 hooks: vec![
                     Hook {
                         key: "first".to_string(),
-                        command: vec!["echo".to_string()],
+                        command: HookCommand::Array(vec!["echo".to_string()]),
                         default: Some(false),
                         ..Default::default()
                     },
                     Hook {
                         key: "second".to_string(),
-                        command: vec!["echo".to_string()],
+                        command: HookCommand::Array(vec!["echo".to_string()]),
                         r#if: Some("{{ hook_ran_first }}".to_string()),
                         default: Some(true),
                         ..Default::default()
@@ -1491,7 +1639,10 @@ mod tests {
                 name: "command templating with slot data",
                 hooks: vec![Hook {
                     key: "h1".to_string(),
-                    command: vec!["echo".to_string(), "Hello {{ name }}".to_string()],
+                    command: HookCommand::Array(vec![
+                        "echo".to_string(),
+                        "Hello {{ name }}".to_string(),
+                    ]),
                     default: Some(true),
                     ..Default::default()
                 }],
@@ -1503,7 +1654,10 @@ mod tests {
                 name: "command template error → should_run=false + template_error skip",
                 hooks: vec![Hook {
                     key: "broken".to_string(),
-                    command: vec!["echo".to_string(), "{{ undefined_var }}".to_string()],
+                    command: HookCommand::Array(vec![
+                        "echo".to_string(),
+                        "{{ undefined_var }}".to_string(),
+                    ]),
                     default: Some(true),
                     ..Default::default()
                 }],
@@ -1516,13 +1670,13 @@ mod tests {
                 hooks: vec![
                     Hook {
                         key: "broken".to_string(),
-                        command: vec!["{{ undefined }}".to_string()],
+                        command: HookCommand::Array(vec!["{{ undefined }}".to_string()]),
                         default: Some(true),
                         ..Default::default()
                     },
                     Hook {
                         key: "after".to_string(),
-                        command: vec!["echo".to_string()],
+                        command: HookCommand::Array(vec!["echo".to_string()]),
                         r#if: Some("{{ hook_ran_broken }}".to_string()),
                         default: Some(true),
                         ..Default::default()
@@ -1581,7 +1735,7 @@ mod tests {
             if c.name == "command templating with slot data" {
                 assert_eq!(
                     plan[0].command,
-                    vec!["echo", "Hello world"],
+                    vec!["bash", "-c", "echo 'Hello world'"],
                     "case {}: templated command",
                     c.name
                 );
@@ -1603,170 +1757,161 @@ mod tests {
         }
     }
 
-    // --- normalize_hook_command_for_execution ---
+    // --- HookCommand rendering + denylist ---
 
     fn vs(args: &[&str]) -> Vec<String> {
         args.iter().map(|s| s.to_string()).collect()
     }
 
+    fn arr(args: &[&str]) -> HookCommand {
+        HookCommand::Array(vs(args))
+    }
+
+    fn ctx(data: &HashMap<String, String>) -> Context {
+        Context::from_serialize(data).expect("context")
+    }
+
     #[test]
-    fn normalize_hook_command_for_execution_table() {
+    fn render_command_table() {
+        let empty = HashMap::new();
+        let name_hi = HashMap::from([("name".to_string(), "hi".to_string())]);
+        let name_meta = HashMap::from([("name".to_string(), "a; b".to_string())]);
+
         struct Case {
             name: &'static str,
-            input: Vec<String>,
-            expected: Result<Vec<String>, ()>, // Err(()) means "any HookCommandError"
+            cmd: HookCommand,
+            data: HashMap<String, String>,
+            // Full expected argv (always begins with bash, -c).
+            expected: Vec<&'static str>,
         }
 
         let cases = vec![
             Case {
-                name: "empty",
-                input: vec![],
-                expected: Ok(vec![]),
+                name: "string raw",
+                cmd: HookCommand::String("echo hi && echo done".to_string()),
+                data: empty.clone(),
+                expected: vec!["bash", "-c", "echo hi && echo done"],
             },
             Case {
-                name: "no operators",
-                input: vs(&["echo", "hi"]),
-                expected: Ok(vs(&["echo", "hi"])),
+                name: "string raw substitution",
+                cmd: HookCommand::String("echo {{ name }} && echo done".to_string()),
+                data: name_hi.clone(),
+                expected: vec!["bash", "-c", "echo hi && echo done"],
             },
             Case {
-                name: "operator between args",
-                input: vs(&["git", "init", "&&", "git", "add", "."]),
-                expected: Ok(vs(&["bash", "-c", "git init && git add ."])),
+                name: "array simple",
+                cmd: arr(&["echo", "hi"]),
+                data: empty.clone(),
+                expected: vec!["bash", "-c", "echo hi"],
             },
             Case {
-                name: "operator with quoted arg",
-                input: vs(&[
-                    "git",
-                    "commit",
-                    "-m",
-                    "initial commit",
-                    "&&",
-                    "git",
-                    "status",
-                ]),
-                expected: Ok(vs(&[
-                    "bash",
-                    "-c",
-                    "git commit -m 'initial commit' && git status",
-                ])),
+                name: "array whitespace gets quoted",
+                cmd: arr(&["echo", "hello world"]),
+                data: empty.clone(),
+                expected: vec!["bash", "-c", "echo 'hello world'"],
             },
             Case {
-                name: "arg with single quote",
-                input: vs(&["echo", "it's", "&&", "true"]),
-                expected: Ok(vs(&["bash", "-c", "echo 'it'\\''s' && true"])),
+                name: "array operators pass through",
+                cmd: arr(&["git", "init", "&&", "git", "add", "."]),
+                data: empty.clone(),
+                expected: vec!["bash", "-c", "git init && git add ."],
             },
             Case {
-                name: "arg with $ stays literal via single-quote",
-                input: vs(&["echo", "$PATH", "&&", "echo", "done"]),
-                expected: Ok(vs(&["bash", "-c", "echo '$PATH' && echo done"])),
+                name: "array template is literal",
+                cmd: arr(&["echo", "{{ name }}", "&&", "echo", "done"]),
+                data: name_hi.clone(),
+                expected: vec!["bash", "-c", "echo hi && echo done"],
             },
             Case {
-                name: "pipe operator",
-                input: vs(&["cat", "f", "|", "wc", "-l"]),
-                expected: Ok(vs(&["bash", "-c", "cat f | wc -l"])),
+                name: "array template with metachars stays literal",
+                cmd: arr(&["echo", "{{ name }}"]),
+                data: name_meta.clone(),
+                expected: vec!["bash", "-c", "echo 'a; b'"],
             },
             Case {
-                name: "or operator",
-                input: vs(&["false", "||", "true"]),
-                expected: Ok(vs(&["bash", "-c", "false || true"])),
+                name: "bash -c passthrough templates body",
+                cmd: arr(&["bash", "-c", "echo {{ name }} && echo done"]),
+                data: name_hi.clone(),
+                expected: vec!["bash", "-c", "echo hi && echo done"],
             },
             Case {
-                name: "semicolon operator",
-                input: vs(&["true", ";", "echo", "hi"]),
-                expected: Ok(vs(&["bash", "-c", "true ; echo hi"])),
+                name: "sh -c passthrough",
+                cmd: arr(&["sh", "-c", "x && y"]),
+                data: empty.clone(),
+                expected: vec!["bash", "-c", "x && y"],
             },
             Case {
-                name: "operator as substring NOT triggered",
-                input: vs(&["echo", "a&&b"]),
-                expected: Ok(vs(&["echo", "a&&b"])),
-            },
-            Case {
-                name: "already wrapped (bash)",
-                input: vs(&["bash", "-c", "x && y"]),
-                expected: Ok(vs(&["bash", "-c", "x && y"])),
-            },
-            Case {
-                name: "already wrapped (sh)",
-                input: vs(&["sh", "-c", "x && y"]),
-                expected: Ok(vs(&["sh", "-c", "x && y"])),
-            },
-            Case {
-                name: "single-element with operator tokens",
-                input: vs(&["git init && git add ."]),
-                expected: Ok(vs(&["bash", "-c", "git init && git add ."])),
-            },
-            Case {
-                name: "single-element no operator",
-                input: vs(&["echo hi"]),
-                expected: Ok(vs(&["echo hi"])),
-            },
-            Case {
-                name: "operator + {{ name }} → err",
-                input: vs(&["echo", "{{ name }}", "&&", "echo", "hi"]),
-                expected: Err(()),
-            },
-            Case {
-                name: "operator + {% if %} → err",
-                input: vs(&["{% if x %}echo a{% endif %}", "&&", "echo", "b"]),
-                expected: Err(()),
-            },
-            Case {
-                name: "operator + {# comment #} → err",
-                input: vs(&["echo", "{# c #}", "&&", "echo", "b"]),
-                expected: Err(()),
-            },
-            Case {
-                name: "template only, no operator → unchanged",
-                input: vs(&["echo", "{{ name }}"]),
-                expected: Ok(vs(&["echo", "{{ name }}"])),
+                name: "bash -c passthrough preserves positional args",
+                cmd: arr(&["bash", "-c", "echo {{ name }}", "argzero"]),
+                data: name_hi.clone(),
+                expected: vec!["bash", "-c", "echo hi", "argzero"],
             },
         ];
 
         for c in cases {
-            let got = normalize_hook_command_for_execution(&c.input);
-            match (&c.expected, &got) {
-                (Ok(exp), Ok(actual)) => {
-                    assert_eq!(actual, exp, "case {}", c.name);
-                }
-                (Err(_), Err(_)) => {
-                    // any HookCommandError is fine; current enum has one variant
-                }
-                _ => panic!(
-                    "case {}: result mismatch — expected {:?}, got {:?}",
-                    c.name, c.expected, got
-                ),
-            }
+            let got = render_command(&c.cmd, &ctx(&c.data)).expect(c.name);
+            assert_eq!(got, c.expected, "case {}", c.name);
         }
     }
 
     #[test]
-    fn normalize_hook_command_idempotent() {
-        let cases = vec![
-            vs(&["git", "init", "&&", "git", "add", "."]),
-            vs(&[
-                "git",
-                "commit",
-                "-m",
-                "initial commit",
-                "&&",
-                "git",
-                "status",
-            ]),
-            vs(&["echo", "$PATH", "&&", "echo", "done"]),
-            vs(&["git init && git add ."]),
+    fn dangerous_pattern_check_table() {
+        // (input, expected_ok)
+        let cases: Vec<(&str, bool)> = vec![
+            ("echo hi", true),
+            ("rm -rf build", true),
+            ("rm -rf /tmp/foo", true),
+            ("rm -r /", true), // recursive but not forced
+            ("rm -f /", true), // forced but not recursive
+            ("rm -rf /", false),
+            ("rm -rf /*", false),
+            ("rm -fr /", false),
+            ("rm --recursive --force /", false),
+            ("rm -rf /etc", false),
+            ("rm -rf /usr/", false),
+            ("sudo rm -rf / --no-preserve-root", false),
+            ("doas rm -rf /", false),
+            ("echo done && rm -rf /", false),
+            ("true && sudo rm -rf /etc", false),
+            (":(){ :|:& };:", false),
+            (":(){:|:&};:", false),
+            // Separators that are NOT whitespace-padded must still split the
+            // body so the trailing `rm` is recognized as a command.
+            ("echo safe; rm -rf /", false),
+            ("echo safe;rm -rf /", false),
+            ("echo safe&&rm -rf /", false),
+            ("echo safe||rm -rf /", false),
+            ("echo safe|rm -rf /", false),
+            ("echo safe & rm -rf /", false),
+            ("echo safe\nrm -rf /", false),
+            // A quoted literal containing the text is data, not an executable
+            // command — correctly NOT flagged, even with an inner separator.
+            ("echo 'rm -rf /'", true),
+            ("echo 'a; rm -rf /'", true),
+            ("echo \"a; rm -rf /\"", true),
+            // `rm` as an ARGUMENT to another command is not an rm invocation —
+            // must NOT be flagged (array form promises literal arguments).
+            ("echo rm -rf /", true),
+            ("printf rm -rf /", true),
+            ("git commit -m rm -rf /", true),
+            // ...but a real rm after a separator still is.
+            ("echo rm && rm -rf /", false),
         ];
-        for input in cases {
-            let once = normalize_hook_command_for_execution(&input).expect("first pass");
-            let twice = normalize_hook_command_for_execution(&once).expect("second pass");
-            assert_eq!(once, twice, "idempotency for {:?}", input);
+        for (input, ok) in cases {
+            assert_eq!(
+                dangerous_pattern_check(input).is_ok(),
+                ok,
+                "input {:?}",
+                input
+            );
         }
     }
 
     #[test]
-    fn evaluate_hook_plan_auto_wrap_basic() {
+    fn evaluate_hook_plan_array_chain_wraps() {
         let hooks = vec![Hook {
             key: "chain".to_string(),
-            command: vs(&["git", "init", "&&", "git", "add", "."]),
+            command: arr(&["git", "init", "&&", "git", "add", "."]),
             default: Some(true),
             ..Hook::default()
         }];
@@ -1781,58 +1926,138 @@ mod tests {
     }
 
     #[test]
-    fn evaluate_hook_plan_auto_wrap_collision_errors() {
+    fn evaluate_hook_plan_array_template_operator_is_safe() {
+        // Previously a hard collision error; now template-then-quote makes
+        // the slot value a literal argument, so the hook runs and downstream
+        // conditionals see it ran.
         let hooks = vec![
             Hook {
-                key: "broken".to_string(),
-                command: vs(&["echo", "{{ name }}", "&&", "echo", "done"]),
+                key: "first".to_string(),
+                command: arr(&["echo", "{{ name }}", "&&", "echo", "done"]),
                 default: Some(true),
                 ..Hook::default()
             },
             Hook {
                 key: "after".to_string(),
-                command: vs(&["echo", "after"]),
-                r#if: Some("{{ hook_ran_broken }}".to_string()),
+                command: arr(&["echo", "after"]),
+                r#if: Some("{{ hook_ran_first }}".to_string()),
                 default: Some(true),
                 ..Hook::default()
             },
         ];
-        let data = HashMap::from([("name".to_string(), "hi".to_string())]);
+        let data = HashMap::from([("name".to_string(), "evil; rm x".to_string())]);
         let plan = evaluate_hook_plan(&hooks, &[], &data);
         assert_eq!(plan.len(), 2);
-        assert!(!plan[0].should_run);
-        assert_eq!(plan[0].skip_reason.as_deref(), Some("template_error"));
-        assert!(
-            plan[0].template_errors[0].contains("shell injection"),
-            "got {:?}",
-            plan[0].template_errors
+        assert!(plan[0].should_run, "got {:?}", plan[0]);
+        assert_eq!(
+            plan[0].command,
+            vs(&["bash", "-c", "echo 'evil; rm x' && echo done"])
         );
-        // hook_ran_broken must remain false → downstream conditional fails
-        assert!(!plan[1].should_run);
-        assert_eq!(plan[1].skip_reason.as_deref(), Some("false_conditional"));
+        assert!(plan[1].should_run);
     }
 
     #[test]
-    fn evaluate_hook_plan_already_wrapped_passthrough() {
+    fn evaluate_hook_plan_string_form_raw_substitution() {
         let hooks = vec![Hook {
-            key: "explicit".to_string(),
-            command: vs(&["bash", "-c", "echo {{ name }} && echo done"]),
+            key: "s".to_string(),
+            command: HookCommand::String("echo {{ name }} && echo done".to_string()),
             default: Some(true),
             ..Hook::default()
         }];
         let data = HashMap::from([("name".to_string(), "hi".to_string())]);
         let plan = evaluate_hook_plan(&hooks, &[], &data);
         assert!(plan[0].should_run);
-        // Templating still runs on the body, so {{ name }} → hi
         assert_eq!(plan[0].command, vs(&["bash", "-c", "echo hi && echo done"]));
     }
 
     #[test]
-    fn run_hooks_stream_chained_command_executes() {
+    fn evaluate_hook_plan_bash_c_passthrough() {
+        let hooks = vec![Hook {
+            key: "explicit".to_string(),
+            command: arr(&["bash", "-c", "echo {{ name }} && echo done"]),
+            default: Some(true),
+            ..Hook::default()
+        }];
+        let data = HashMap::from([("name".to_string(), "hi".to_string())]);
+        let plan = evaluate_hook_plan(&hooks, &[], &data);
+        assert!(plan[0].should_run);
+        assert_eq!(plan[0].command, vs(&["bash", "-c", "echo hi && echo done"]));
+    }
+
+    #[test]
+    fn evaluate_hook_plan_bash_c_with_positionals_is_scanned() {
+        // Regression: a `bash -c` array with extra positional args must NOT
+        // bypass the denylist. The `-c` body (argv[2]) is rendered verbatim
+        // and scanned, so a slot-injected `rm -rf /` is still caught.
+        let hooks = vec![Hook {
+            key: "sneaky".to_string(),
+            command: arr(&["bash", "-c", "rm -rf {{ target }}", "x"]),
+            default: Some(true),
+            ..Hook::default()
+        }];
+        let data = HashMap::from([("target".to_string(), "/".to_string())]);
+        let plan = evaluate_hook_plan(&hooks, &[], &data);
+        assert!(!plan[0].should_run, "got {:?}", plan[0]);
+        assert_eq!(plan[0].skip_reason.as_deref(), Some("template_error"));
+        assert!(
+            plan[0].template_errors[0].contains("dangerous"),
+            "got {:?}",
+            plan[0].template_errors
+        );
+    }
+
+    #[test]
+    fn evaluate_hook_plan_command_arg_named_rm_is_not_flagged() {
+        // Array form promises literal arguments: `rm` passed to `echo` is
+        // data, not a command, and must run.
+        let hooks = vec![Hook {
+            key: "echo_rm".to_string(),
+            command: arr(&["echo", "rm", "-rf", "/"]),
+            default: Some(true),
+            ..Hook::default()
+        }];
+        let plan = evaluate_hook_plan(&hooks, &[], &HashMap::new());
+        assert!(plan[0].should_run, "got {:?}", plan[0]);
+        assert_eq!(plan[0].command, vs(&["bash", "-c", "echo rm -rf /"]));
+    }
+
+    #[test]
+    fn evaluate_hook_plan_denylist_blocks() {
+        let hooks = vec![
+            Hook {
+                key: "danger".to_string(),
+                command: arr(&["rm", "-rf", "/"]),
+                default: Some(true),
+                ..Hook::default()
+            },
+            Hook {
+                key: "after".to_string(),
+                command: arr(&["echo", "after"]),
+                r#if: Some("{{ hook_ran_danger }}".to_string()),
+                default: Some(true),
+                ..Hook::default()
+            },
+        ];
+        let plan = evaluate_hook_plan(&hooks, &[], &HashMap::new());
+        assert_eq!(plan.len(), 2);
+        assert!(!plan[0].should_run);
+        assert_eq!(plan[0].skip_reason.as_deref(), Some("template_error"));
+        assert!(
+            plan[0].template_errors[0].contains("dangerous"),
+            "got {:?}",
+            plan[0].template_errors
+        );
+        // hook_ran_danger stays false → downstream conditional fails
+        assert!(!plan[1].should_run);
+        assert_eq!(plan[1].skip_reason.as_deref(), Some("false_conditional"));
+    }
+
+    #[test]
+    fn run_hooks_stream_array_chain_executes() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let hooks = vec![Hook {
             key: "chain".to_string(),
-            command: vs(&["touch", "a", "&&", "touch", "b"]),
+            command: arr(&["touch", "a", "&&", "touch", "b"]),
             ..Hook::default()
         }];
         let results = run_hooks(&hooks, tmp.path(), &Vec::new(), &HashMap::new(), None)
@@ -1853,86 +2078,11 @@ mod tests {
     }
 
     #[test]
-    fn run_hooks_stream_chained_with_template_errors_invalid_command() {
-        let hooks = vec![Hook {
-            key: "broken".to_string(),
-            command: vs(&["touch", "{{ name }}/a", "&&", "touch", "{{ name }}/b"]),
-            ..Hook::default()
-        }];
-        let err = run_hooks(
-            &hooks,
-            ".",
-            &Vec::new(),
-            &HashMap::from([("name".to_string(), "x".to_string())]),
-            None,
-        )
-        .expect_err("expected InvalidHookCommand error");
-
-        // Display must include both the hook key and the source message
-        // so the CLI surfaces the actual collision reason.
-        let msg = err.to_string();
-        assert!(
-            msg.contains("'broken'"),
-            "expected hook key in msg, got: {}",
-            msg
-        );
-        assert!(
-            msg.contains("shell injection"),
-            "expected source error text in msg, got: {}",
-            msg
-        );
-
-        match err {
-            Error::InvalidHookCommand(_, HookCommandError::OperatorTemplateCollision { .. }) => {}
-            other => panic!("expected InvalidHookCommand, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn validate_config_flags_operator_template_collision() {
-        let hooks = vec![
-            Hook {
-                key: "broken".to_string(),
-                command: vs(&["echo", "{{ name }}", "&&", "echo", "done"]),
-                ..Hook::default()
-            },
-            Hook {
-                key: "fine".to_string(),
-                command: vs(&["echo", "hi"]),
-                ..Hook::default()
-            },
-            Hook {
-                key: "fine_chain".to_string(),
-                command: vs(&["touch", "a", "&&", "touch", "b"]),
-                ..Hook::default()
-            },
-        ];
-        let errors = validate_config(&hooks, &[]);
-
-        let collision: Vec<_> = errors
-            .iter()
-            .filter(|e| e.code == Some("hook::command_shell_injection_risk"))
-            .collect();
-        assert_eq!(
-            collision.len(),
-            1,
-            "expected exactly one collision diag, got {:#?}",
-            errors
-        );
-        assert_eq!(collision[0].hook_key, "broken");
-        assert!(
-            collision[0].message.contains("shell injection"),
-            "expected shell injection mention, got: {}",
-            collision[0].message
-        );
-    }
-
-    #[test]
-    fn run_hooks_stream_explicit_bash_with_template_runs() {
+    fn run_hooks_stream_string_form_executes() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let hooks = vec![Hook {
-            key: "explicit".to_string(),
-            command: vs(&["bash", "-c", "touch {{ name }} && touch other"]),
+            key: "s".to_string(),
+            command: HookCommand::String("touch {{ name }} && touch other".to_string()),
             ..Hook::default()
         }];
         let results = run_hooks(
@@ -1952,5 +2102,113 @@ mod tests {
         )));
         assert!(tmp.path().join("first").exists());
         assert!(tmp.path().join("other").exists());
+    }
+
+    #[test]
+    fn run_hooks_stream_array_literal_substitution() {
+        // A slot value with shell metacharacters becomes ONE literal argument
+        // (a filename), not a second command.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let hooks = vec![Hook {
+            key: "lit".to_string(),
+            command: arr(&["touch", "{{ name }}"]),
+            ..Hook::default()
+        }];
+        let evil = "weird; name";
+        let results = run_hooks(
+            &hooks,
+            tmp.path(),
+            &Vec::new(),
+            &HashMap::from([("name".to_string(), evil.to_string())]),
+            None,
+        )
+        .expect("run_hooks failed");
+        assert!(results.iter().all(|r| matches!(
+            r,
+            HookResult {
+                kind: HookResultKind::Completed { .. },
+                ..
+            }
+        )));
+        assert!(
+            tmp.path().join(evil).exists(),
+            "file with literal name should exist"
+        );
+        // No injection: the metachar split must NOT have created a bare 'name'.
+        assert!(!tmp.path().join("name").exists());
+    }
+
+    #[test]
+    fn run_hooks_stream_denylist_blocks() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let hooks = vec![Hook {
+            key: "danger".to_string(),
+            command: HookCommand::String("rm -rf /".to_string()),
+            ..Hook::default()
+        }];
+        let err = run_hooks(&hooks, tmp.path(), &Vec::new(), &HashMap::new(), None)
+            .expect_err("expected InvalidHookCommand error");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("'danger'"),
+            "expected hook key in msg, got: {}",
+            msg
+        );
+        assert!(
+            msg.contains("dangerous"),
+            "expected denylist text, got: {}",
+            msg
+        );
+
+        match err {
+            Error::InvalidHookCommand(_, HookCommandError::DangerousPattern { .. }) => {}
+            other => panic!(
+                "expected InvalidHookCommand/DangerousPattern, got {:?}",
+                other
+            ),
+        }
+    }
+
+    #[test]
+    fn validate_config_flags_dangerous_pattern() {
+        let hooks = vec![
+            Hook {
+                key: "danger".to_string(),
+                command: arr(&["rm", "-rf", "/"]),
+                ..Hook::default()
+            },
+            Hook {
+                key: "fine".to_string(),
+                command: arr(&["echo", "hi"]),
+                ..Hook::default()
+            },
+            Hook {
+                key: "fine_chain".to_string(),
+                command: arr(&["touch", "a", "&&", "touch", "b"]),
+                ..Hook::default()
+            },
+            // Array literal containing an inner separator: posix-quoted at
+            // runtime, so it's data, not a chained `rm`. The static scan must
+            // mirror that and NOT flag it.
+            Hook {
+                key: "quoted_literal".to_string(),
+                command: arr(&["echo", "safe; rm -rf /"]),
+                ..Hook::default()
+            },
+        ];
+        let errors = validate_config(&hooks, &[]);
+
+        let flagged: Vec<_> = errors
+            .iter()
+            .filter(|e| e.code == Some("hook::command_dangerous_pattern"))
+            .collect();
+        assert_eq!(
+            flagged.len(),
+            1,
+            "expected exactly one dangerous-pattern diag, got {:#?}",
+            errors
+        );
+        assert_eq!(flagged[0].hook_key, "danger");
     }
 }

--- a/src/template.rs
+++ b/src/template.rs
@@ -570,7 +570,10 @@ mod tests {
         // render call unless the target transitively references it.
         let mut templates = HashMap::new();
         templates.insert("target.j2".to_string(), "ok".to_string());
-        templates.insert("unrelated.j2".to_string(), "{{ undefined_var }}".to_string());
+        templates.insert(
+            "unrelated.j2".to_string(),
+            "{{ undefined_var }}".to_string(),
+        );
         let data: HashMap<String, String> = HashMap::new();
         let out = render_one_from_memory(&templates, "target.j2", &data).expect("render ok");
         assert_eq!(out, "ok");
@@ -618,8 +621,16 @@ mod tests {
         match err {
             ValidateError::RenderError(errs) => {
                 let files: Vec<&str> = errs.iter().map(|e| e.file.as_str()).collect();
-                assert!(files.contains(&"bad.j2"), "expected bad.j2 in errs: {:?}", files);
-                assert!(!files.contains(&"good.j2"), "good.j2 wrongly flagged: {:?}", files);
+                assert!(
+                    files.contains(&"bad.j2"),
+                    "expected bad.j2 in errs: {:?}",
+                    files
+                );
+                assert!(
+                    !files.contains(&"good.j2"),
+                    "good.j2 wrongly flagged: {:?}",
+                    files
+                );
             }
             _ => panic!("expected RenderError"),
         }
@@ -651,8 +662,16 @@ mod tests {
             .filter_map(|r| r.as_ref().err())
             .map(|e| e.file.clone())
             .collect();
-        assert!(oks.contains(&"a.j2".to_string()), "a.j2 missing from oks: {:?}", oks);
-        assert!(oks.contains(&"b.j2".to_string()), "b.j2 missing from oks: {:?}", oks);
+        assert!(
+            oks.contains(&"a.j2".to_string()),
+            "a.j2 missing from oks: {:?}",
+            oks
+        );
+        assert!(
+            oks.contains(&"b.j2".to_string()),
+            "b.j2 missing from oks: {:?}",
+            oks
+        );
         assert_eq!(errs, vec!["bad.j2".to_string()]);
     }
 
@@ -786,5 +805,4 @@ mod tests {
             );
         }
     }
-
 }

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2-ai/spackle",
-  "version": "0.5.1-rc2",
+  "version": "0.5.1-rc3",
   "description": "spackle project templating, as a WebAssembly module for JS hosts.",
   "repository": "https://github.com/a2-ai/spackle",
   "files": [

--- a/ts/tests/hooks.test.ts
+++ b/ts/tests/hooks.test.ts
@@ -445,7 +445,7 @@ default = true
     const bundle = [{ path: "/project/spackle.toml", bytes: new TextEncoder().encode(toml) }];
 
     const mock = new MockHooks((cmd) => {
-      if (cmd.includes("fail")) return { exitCode: 1, ok: false };
+      if (cmd.some((c) => c.includes("fail"))) return { exitCode: 1, ok: false };
       return {};
     });
 
@@ -598,7 +598,7 @@ default = true
     // despite the consumer's mutations.
     expect(mock.calls.length).toBe(3);
     for (const call of mock.calls) {
-      expect(call.command[0]).toBe("sh");
+      expect(call.command[0]).toBe("bash");
       expect(call.command.includes("not-a-real-binary")).toBe(false);
     }
   });
@@ -641,14 +641,14 @@ default = true
   });
 });
 
-describe("auto-wrap chained commands", () => {
+describe("hook command forms", () => {
   const cleanup: string[] = [];
   beforeEach(() => void (cleanup.length = 0));
   afterEach(async () => {
     await Promise.all(cleanup.map((p) => rm(p, { recursive: true, force: true })));
   });
 
-  async function runPlanWithMock(toml: string, mock: MockHooks, cwd: string) {
+  async function runPlanWithMock(toml: string, mock: MockHooks, cwd: string, data = {}) {
     const bundle = [{ path: "/project/spackle.toml", bytes: new TextEncoder().encode(toml) }];
     const { loadSpackleWasm } = await import("../src/wasm/index.ts");
     const wasm = await loadSpackleWasm();
@@ -657,14 +657,14 @@ describe("auto-wrap chained commands", () => {
         bundle,
         projectDir: "/project",
         outDir: "/tmp/out",
-        data: {},
+        data,
         hooks: mock,
         cwd,
       }),
     );
   }
 
-  test("operator-as-element produces bash -c wrapped argv at execute()", async () => {
+  test("array operator-as-element produces bash -c wrapped argv at execute()", async () => {
     const toml = `
 [[hooks]]
 key = "chain"
@@ -677,7 +677,7 @@ default = true
     expect(mock.calls[0]?.command).toEqual(["bash", "-c", "touch a && touch b"]);
   });
 
-  test("args with whitespace are POSIX-quoted in the shell body", async () => {
+  test("array args with whitespace are POSIX-quoted in the shell body", async () => {
     const toml = `
 [[hooks]]
 key = "commit"
@@ -694,7 +694,7 @@ default = true
     ]);
   });
 
-  test("operator-as-substring is left untouched", async () => {
+  test("array operator-as-substring is quoted, not split", async () => {
     const toml = `
 [[hooks]]
 key = "noop"
@@ -704,7 +704,7 @@ default = true
     const mock = new MockHooks();
     await runPlanWithMock(toml, mock, "/tmp");
     expect(mock.calls.length).toBe(1);
-    expect(mock.calls[0]?.command).toEqual(["echo", "a&&b"]);
+    expect(mock.calls[0]?.command).toEqual(["bash", "-c", "echo 'a&&b'"]);
   });
 
   test("already-wrapped bash -c argv passes through unchanged", async () => {
@@ -720,11 +720,37 @@ default = true
     expect(mock.calls[0]?.command).toEqual(["bash", "-c", "echo hi && echo there"]);
   });
 
-  test("operator + template expression yields terminal template_errors", async () => {
+  test("array operator + template renders a literal, safely quoted argument", async () => {
     const toml = `
 [[hooks]]
-key = "broken"
+key = "first"
 command = ["echo", "{{ name }}", "&&", "echo", "done"]
+default = true
+`;
+    const mock = new MockHooks();
+    await runPlanWithMock(toml, mock, "/tmp", { name: "evil; rm x" });
+    expect(mock.calls.length).toBe(1);
+    expect(mock.calls[0]?.command).toEqual(["bash", "-c", "echo 'evil; rm x' && echo done"]);
+  });
+
+  test("string form renders with raw substitution", async () => {
+    const toml = `
+[[hooks]]
+key = "s"
+command = "echo {{ name }} && echo done"
+default = true
+`;
+    const mock = new MockHooks();
+    await runPlanWithMock(toml, mock, "/tmp", { name: "hi" });
+    expect(mock.calls.length).toBe(1);
+    expect(mock.calls[0]?.command).toEqual(["bash", "-c", "echo hi && echo done"]);
+  });
+
+  test("dangerous command is blocked with terminal template_errors", async () => {
+    const toml = `
+[[hooks]]
+key = "danger"
+command = "rm -rf /"
 default = true
 `;
     const bundle = [{ path: "/project/spackle.toml", bytes: new TextEncoder().encode(toml) }];
@@ -736,7 +762,7 @@ default = true
         bundle,
         projectDir: "/project",
         outDir: "/tmp/out",
-        data: { name: "hi" },
+        data: {},
         hooks: mock,
         cwd: "/tmp",
       }),
@@ -746,9 +772,9 @@ default = true
     const terminal = events[events.length - 1];
     expect(terminal?.type).toBe("template_errors");
     if (terminal?.type === "template_errors") {
-      expect(terminal.templateErrors[0]?.key).toBe("broken");
+      expect(terminal.templateErrors[0]?.key).toBe("danger");
       const msg = terminal.templateErrors[0]?.errors[0] ?? "";
-      expect(msg).toContain("shell injection");
+      expect(msg).toContain("dangerous");
     }
   });
 

--- a/ts/tests/hooks.test.ts
+++ b/ts/tests/hooks.test.ts
@@ -640,3 +640,153 @@ default = true
     expect(mock.calls.length).toBe(0);
   });
 });
+
+describe("auto-wrap chained commands", () => {
+  const cleanup: string[] = [];
+  beforeEach(() => void (cleanup.length = 0));
+  afterEach(async () => {
+    await Promise.all(cleanup.map((p) => rm(p, { recursive: true, force: true })));
+  });
+
+  async function runPlanWithMock(toml: string, mock: MockHooks, cwd: string) {
+    const bundle = [{ path: "/project/spackle.toml", bytes: new TextEncoder().encode(toml) }];
+    const { loadSpackleWasm } = await import("../src/wasm/index.ts");
+    const wasm = await loadSpackleWasm();
+    return drain(
+      runHookPlanStream((b, pdir, odir, d, hr) => wasm.planHooks(b, pdir, odir, d, hr), {
+        bundle,
+        projectDir: "/project",
+        outDir: "/tmp/out",
+        data: {},
+        hooks: mock,
+        cwd,
+      }),
+    );
+  }
+
+  test("operator-as-element produces bash -c wrapped argv at execute()", async () => {
+    const toml = `
+[[hooks]]
+key = "chain"
+command = ["touch", "a", "&&", "touch", "b"]
+default = true
+`;
+    const mock = new MockHooks();
+    await runPlanWithMock(toml, mock, "/tmp");
+    expect(mock.calls.length).toBe(1);
+    expect(mock.calls[0]?.command).toEqual(["bash", "-c", "touch a && touch b"]);
+  });
+
+  test("args with whitespace are POSIX-quoted in the shell body", async () => {
+    const toml = `
+[[hooks]]
+key = "commit"
+command = ["git", "commit", "-m", "initial commit", "&&", "git", "status"]
+default = true
+`;
+    const mock = new MockHooks();
+    await runPlanWithMock(toml, mock, "/tmp");
+    expect(mock.calls.length).toBe(1);
+    expect(mock.calls[0]?.command).toEqual([
+      "bash",
+      "-c",
+      "git commit -m 'initial commit' && git status",
+    ]);
+  });
+
+  test("operator-as-substring is left untouched", async () => {
+    const toml = `
+[[hooks]]
+key = "noop"
+command = ["echo", "a&&b"]
+default = true
+`;
+    const mock = new MockHooks();
+    await runPlanWithMock(toml, mock, "/tmp");
+    expect(mock.calls.length).toBe(1);
+    expect(mock.calls[0]?.command).toEqual(["echo", "a&&b"]);
+  });
+
+  test("already-wrapped bash -c argv passes through unchanged", async () => {
+    const toml = `
+[[hooks]]
+key = "explicit"
+command = ["bash", "-c", "echo hi && echo there"]
+default = true
+`;
+    const mock = new MockHooks();
+    await runPlanWithMock(toml, mock, "/tmp");
+    expect(mock.calls.length).toBe(1);
+    expect(mock.calls[0]?.command).toEqual(["bash", "-c", "echo hi && echo there"]);
+  });
+
+  test("operator + template expression yields terminal template_errors", async () => {
+    const toml = `
+[[hooks]]
+key = "broken"
+command = ["echo", "{{ name }}", "&&", "echo", "done"]
+default = true
+`;
+    const bundle = [{ path: "/project/spackle.toml", bytes: new TextEncoder().encode(toml) }];
+    const mock = new MockHooks();
+    const { loadSpackleWasm } = await import("../src/wasm/index.ts");
+    const wasm = await loadSpackleWasm();
+    const events = await drain(
+      runHookPlanStream((b, pdir, odir, d, hr) => wasm.planHooks(b, pdir, odir, d, hr), {
+        bundle,
+        projectDir: "/project",
+        outDir: "/tmp/out",
+        data: { name: "hi" },
+        hooks: mock,
+        cwd: "/tmp",
+      }),
+    );
+
+    expect(mock.calls.length).toBe(0);
+    const terminal = events[events.length - 1];
+    expect(terminal?.type).toBe("template_errors");
+    if (terminal?.type === "template_errors") {
+      expect(terminal.templateErrors[0]?.key).toBe("broken");
+      const msg = terminal.templateErrors[0]?.errors[0] ?? "";
+      expect(msg).toContain("shell injection");
+    }
+  });
+
+  test("real executor runs the chained command and side effects land on disk", async () => {
+    const ws = await workspace("hooks_fixture");
+    cleanup.push(ws.root);
+    // We need a real outDir for the executor cwd. The runHookPlanStream
+    // path uses the cwd argument directly — point both at a temp dir.
+    const { mkdir, stat } = await import("node:fs/promises");
+    await mkdir(ws.outDir, { recursive: true });
+
+    const toml = `
+[[hooks]]
+key = "chain"
+command = ["touch", "a.real", "&&", "touch", "b.real"]
+default = true
+`;
+    const bundle = [{ path: "/project/spackle.toml", bytes: new TextEncoder().encode(toml) }];
+    const { loadSpackleWasm } = await import("../src/wasm/index.ts");
+    const wasm = await loadSpackleWasm();
+    const hooks = defaultHooks();
+    const events = await drain(
+      runHookPlanStream((b, pdir, odir, d, hr) => wasm.planHooks(b, pdir, odir, d, hr), {
+        bundle,
+        projectDir: "/project",
+        outDir: ws.outDir,
+        data: {},
+        hooks,
+        cwd: ws.outDir,
+      }),
+    );
+    expect(events.some((e) => e.type === "template_errors")).toBe(false);
+    expect(events.some((e) => e.type === "plan_error")).toBe(false);
+    const results = resultsOf(events);
+    expect(results.length).toBe(1);
+    expect(results[0]?.kind).toBe("completed");
+
+    await stat(join(ws.outDir, "a.real"));
+    await stat(join(ws.outDir, "b.real"));
+  });
+});


### PR DESCRIPTION
this pr lets users write chained shell commands in hooks naturally instead of having to spell them out

before, the command `["git", "init", "&&", "git", "add", "."]` ran `git init "&&" "git" "add" "."` and predictably failed

after, the same args are auto-wrapped to `["bash", "-c", "git init && git add ."]` at the plan stage, with POSIX-quoting for any whitespace-containing args (`-m "initial commit"` survives intact)

**NOTE**: operator + tera syntax in the same command is refused everywhere; wrapping templated values into a shell string would let slot values inject shell metacharacters that may be malicious/harmful. authors who want this still can opt in explicitly with `["bash", "-c", "..."]` and own their quoting. **we can get rid of this safety constraint if you feel this is excessive**. users of the ui would put in the same escape hatch by putting in something like: `bash -c 'echo {{ name }}'`