### PR TITLE
feat: preserve permissions through node package

### DIFF
--- a/ts/src/host/disk-fs.ts
+++ b/ts/src/host/disk-fs.ts
@@ -4,12 +4,14 @@
 // template bytes via `writeFile`.
 
 import {
+  chmodSync,
   createReadStream,
   createWriteStream,
   existsSync,
   mkdirSync,
   readFileSync,
   realpathSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import {
@@ -79,7 +81,9 @@ export class DiskFs {
     return absOut;
   }
 
-  /** Idempotent `mkdir -p` for `outDir` under `workspaceRoot`. */
+  /** Idempotent `mkdir -p` for `outDir` under `workspaceRoot`. Always
+   * creates the dir writable; preserved directory modes are applied
+   * later via [[chmod]], once descendants are populated. */
   ensureOutDir(outDir: string): string {
     const absOut = this.containDiskForCreate(outDir);
     mkdirSync(absOut, { recursive: true });
@@ -99,18 +103,33 @@ export class DiskFs {
     return resolved;
   }
 
-  /** Write `bytes` at `absPath`, creating parent dirs as needed. */
-  writeFile(absPath: string, bytes: Uint8Array): void {
+  /** Write `bytes` at `absPath`, creating parent dirs as needed. When
+   * `mode` is supplied, chmod after writing so the bits survive umask. */
+  writeFile(absPath: string, bytes: Uint8Array, mode?: number): void {
     mkdirSync(pathDirname(absPath), { recursive: true });
     writeFileSync(absPath, bytes);
+    if (mode !== undefined) chmodSync(absPath, mode);
   }
 
   /** Stream-copy `srcAbs` → `dstAbs` via `pipeline()`. Bytes traverse
    * Node's default ~64 KiB highWaterMark chunks; large files never
-   * sit fully in memory. */
-  async streamCopy(srcAbs: string, dstAbs: string): Promise<void> {
+   * sit fully in memory. When `mode` is supplied, chmod the
+   * destination after the copy completes so the bits survive umask. */
+  async streamCopy(srcAbs: string, dstAbs: string, mode?: number): Promise<void> {
     mkdirSync(pathDirname(dstAbs), { recursive: true });
     await pipeline(createReadStream(srcAbs), createWriteStream(dstAbs));
+    if (mode !== undefined) chmodSync(dstAbs, mode);
+  }
+
+  /** Permission bits (0o777-masked) of an existing path. */
+  modeOf(absPath: string): number {
+    return statSync(absPath).mode & 0o777;
+  }
+
+  /** Apply permission bits to an existing path. Best-effort on Windows
+   * (only the read-only bit is honored there). */
+  chmod(absPath: string, mode: number): void {
+    chmodSync(absPath, mode);
   }
 
   /** Read a single file's bytes from disk. */

--- a/ts/src/spackle.ts
+++ b/ts/src/spackle.ts
@@ -385,6 +385,12 @@ export async function generate(
 
   let files = 0;
   let dirs = 0;
+  // Directory modes are applied after the whole tree is written, never
+  // at creation time: a restrictive source mode (e.g. 0o555 / 0o500)
+  // applied up front would make the output dir non-writable before its
+  // children are copied/rendered into it, breaking generation midway.
+  // Collected in top-down walk order, applied deepest-first below.
+  const dirModes: Array<{ abs: string; mode: number }> = [];
   for (const entry of walkDisk(absProject)) {
     // Classify on the **source** filename, not the rendered path. A
     // static file whose templated name renders to `foo.j2` is still
@@ -406,8 +412,16 @@ export async function generate(
     }
     const renderedRel = pathRes.path;
 
+    // Preserve the source entry's permission bits onto its output so
+    // executable scripts stay executable and restricted files stay
+    // restricted. Templates inherit the mode of their source `.j2` /
+    // `.tera` file.
+    const srcMode = fs.modeOf(entry.absPath);
+
     if (entry.kind === "dir") {
-      fs.ensureOutDir(fs.containedJoin(absOut, renderedRel));
+      const absDir = fs.containedJoin(absOut, renderedRel);
+      fs.ensureOutDir(absDir);
+      dirModes.push({ abs: absDir, mode: srcMode });
       dirs++;
       continue;
     }
@@ -419,7 +433,7 @@ export async function generate(
         if (d) return { ok: false, error: `${d.path ?? entry.relPath}: ${d.message}` };
       }
       const dstAbs = fs.containedJoin(absOut, stripTemplateExt(renderedRel));
-      fs.writeFile(dstAbs, renderRes.bytes);
+      fs.writeFile(dstAbs, renderRes.bytes, srcMode);
       files++;
     } else {
       const dstAbs = fs.containedJoin(absOut, renderedRel);
@@ -427,7 +441,7 @@ export async function generate(
         // Sequential: parallel copies would explode the FD budget on
         // large projects.
         // oxlint-disable-next-line eslint/no-await-in-loop
-        await fs.streamCopy(entry.absPath, dstAbs);
+        await fs.streamCopy(entry.absPath, dstAbs, srcMode);
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
         return { ok: false, error: `${entry.relPath}: ${msg}` };
@@ -438,6 +452,15 @@ export async function generate(
 
   // An all-ignored / empty project still produces an empty `outDir`.
   fs.ensureOutDir(absOut);
+
+  // Deepest-first (reverse of the top-down walk) so every child is
+  // chmodded while its parents are still traversable — a parent locked
+  // to a mode without execute (e.g. 0o444) would otherwise strand its
+  // descendants.
+  for (let i = dirModes.length - 1; i >= 0; i--) {
+    const dir = dirModes[i];
+    if (dir) fs.chmod(dir.abs, dir.mode);
+  }
 
   return { ok: true, files, dirs };
 }

--- a/ts/tests/disk-fs.test.ts
+++ b/ts/tests/disk-fs.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
 import { randomBytes } from "node:crypto";
-import { existsSync } from "node:fs";
+import { chmodSync, existsSync, statSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -126,6 +126,31 @@ describe("DiskFs", () => {
     expect(existsSync(target)).toBe(true);
   });
 
+  const posix = process.platform !== "win32";
+
+  test.if(posix)("writeFile applies the supplied mode", () => {
+    const fs = new DiskFs({ workspaceRoot: root });
+    const target = join(root, "out", "exec.sh");
+    fs.writeFile(target, new TextEncoder().encode("#!/bin/sh\n"), 0o600);
+    expect(statSync(target).mode & 0o777).toBe(0o600);
+  });
+
+  test.if(posix)("chmod applies the supplied mode to an existing path", () => {
+    const fs = new DiskFs({ workspaceRoot: root });
+    const dir = join(root, "secret");
+    fs.ensureOutDir(dir);
+    fs.chmod(dir, 0o555);
+    expect(statSync(dir).mode & 0o777).toBe(0o555);
+  });
+
+  test.if(posix)("modeOf returns the masked permission bits of a path", async () => {
+    const fs = new DiskFs({ workspaceRoot: root });
+    const p = join(root, "m.txt");
+    await writeFile(p, "x");
+    chmodSync(p, 0o640);
+    expect(fs.modeOf(p)).toBe(0o640);
+  });
+
   test("streamCopy pipes bytes through createReadStream/createWriteStream", async () => {
     const fs = new DiskFs({ workspaceRoot: root });
     const srcPath = join(root, "src.bin");
@@ -138,11 +163,14 @@ describe("DiskFs", () => {
     for (let i = 0; i < payload.length; i++) payload[i] = i & 0xff;
     await writeFile(srcPath, payload);
 
-    await fs.streamCopy(srcPath, dstPath);
+    await fs.streamCopy(srcPath, dstPath, 0o755);
 
     const back = await readFile(dstPath);
     expect(back.byteLength).toBe(payload.byteLength);
     expect(new Uint8Array(back)).toEqual(payload);
+    if (process.platform !== "win32") {
+      expect(statSync(dstPath).mode & 0o777).toBe(0o755);
+    }
   });
 
   test("readFile returns the file's bytes", async () => {

--- a/ts/tests/spackle.test.ts
+++ b/ts/tests/spackle.test.ts
@@ -14,6 +14,7 @@
 //     match native semantics
 
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { chmodSync, statSync } from "node:fs";
 import { cp, mkdtemp, realpath, rm, readFile, writeFile, mkdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -197,6 +198,65 @@ describe("spackle (DiskFs)", () => {
       expect(draftThrew).toBe(true);
     }
   });
+
+  // Windows can't represent unix exec/permission bits, so the mode
+  // assertions only run on POSIX.
+  test.if(process.platform !== "win32")(
+    "generate: preserves source permission bits onto output (files, templates, dirs)",
+    async () => {
+      const ws = await workspace("basic_project");
+      cleanup.push(ws.root);
+
+      // Distinctive, non-default modes so the assertions prove *exact*
+      // preservation rather than a coincidental umask default. `docs/`
+      // is a **read-only** (0o555) directory that still contains a
+      // file: it exercises the deferred-chmod path — applying 0o555 at
+      // creation time would block writing `static.md` into it. Chmod
+      // the contained file before the dir so the dir stays writable
+      // while we set up the source tree.
+      chmodSync(join(ws.projectDir, "README.md.j2"), 0o755); // template → exec output
+      chmodSync(join(ws.projectDir, "docs", "static.md"), 0o600); // static copy → 0o600
+      chmodSync(join(ws.projectDir, "src", "{{ filename }}.txt.j2"), 0o640); // template → 0o640
+      chmodSync(join(ws.projectDir, "docs"), 0o555); // read-only directory
+
+      const fs = new DiskFs({ workspaceRoot: ws.root });
+      try {
+        const res = await generate(
+          ws.projectDir,
+          ws.outDir,
+          { greeting: "hi", target: "world", filename: "notes" },
+          fs,
+        );
+        // Generation must SUCCEED even though `docs/` is read-only — the
+        // file inside it is written before the dir mode is applied.
+        expect(res.ok).toBe(true);
+
+        // The file landed inside the read-only dir with the right content.
+        const copied = await readFile(join(ws.outDir, "docs", "static.md"), "utf8");
+        expect(copied).toContain("{{ greeting }}");
+
+        const mode = (...seg: string[]) => statSync(join(ws.outDir, ...seg)).mode & 0o777;
+        // 1. exec bit preserved into rendered template output
+        expect(mode("README.md")).toBe(0o755);
+        // 2. static-copy preservation
+        expect(mode("docs", "static.md")).toBe(0o600);
+        // 3. rendered-template mode from the source template file
+        expect(mode("src", "notes.txt")).toBe(0o640);
+        // 4. read-only directory mode preserved (deepest-first chmod)
+        expect(mode("docs")).toBe(0o555);
+      } finally {
+        // Re-open the read-only dirs so afterEach's `rm -rf` can unlink
+        // their children (a 0o555 parent blocks removal). Wrapping the
+        // generate() call too means a mid-generation throw still leaves
+        // the source dir restorable; the output dir may not exist yet,
+        // so guard it.
+        const { existsSync } = await import("node:fs");
+        chmodSync(join(ws.projectDir, "docs"), 0o755);
+        const outDocs = join(ws.outDir, "docs");
+        if (existsSync(outDocs)) chmodSync(outDocs, 0o755);
+      }
+    },
+  );
 
   test("generate: ignore matches by basename at any depth, not just first segment", async () => {
     // Native `copy::copy_collect` matches the ignore list against


### PR DESCRIPTION
### Preserve file permissions through TS generate()

The TS package walked a project on disk but dropped all permission information — static copies, rendered templates, and created directories all landed with Node's umask defaults (`~0o644` files, `~0o755` dirs). A templated shell script or copied binary that was `0o755` in the project came out non-executable, silently breaking generated projects.

`generate()` now preserves the source entry's permission bits onto its output. Modes are copied exactly (`srcMode` & `0o777`), so `0o600`/`0o640`/`0o755` all survive, not just the executable bit. Applies to all three paths: rendered templates (mode from the source `.j2`/`.tera`), streamed static copies, and directories. Always on: `cp -p`-like semantics, no opt-in flag.

#### Scope

Node package only. `render()` (the in-memory, client-side diagnostics preview) is unchanged; it never touches disk. No changes to the Rust core, native CLI, or wasm boundary.

#### How it works

- `DiskFs` gains a `modeOf()` reader and a `chmod()` primitive; `writeFile`/`streamCopy` take an optional mode applied via `chmodSync` after the write (and after `pipeline()` resolves, so streamed GB-scale assets get their mode on the fully-flushed file).
- Directories are deferred, not `chmod`ded at creation. `ensureOutDir` always creates dirs writable; `generate()` collects each dir's target mode and applies them after the whole tree is written, deepest-first. This is the key correctness point: applying a restrictive dir mode (`0o555`/`0o500`/`0o444`) up front would lock the output dir before its children are populated -- or strand descendants under a no-execute parent -- breaking generation midway.