### PR TITLE
A slot's declared type reaches the template

### DIFF
--- a/crates/spackle-wasm/src/lib.rs
+++ b/crates/spackle-wasm/src/lib.rs
@@ -106,6 +106,18 @@ fn parse_slot_data(slot_data_json: &str) -> Result<HashMap<String, String>, Stri
     serde_json::from_str(slot_data_json).map_err(|e| format!("invalid slot_data_json: {}", e))
 }
 
+/// Slot declarations, so a render can convert each value to its declared
+/// type.
+///
+/// Optional, because the host may not have parsed the config yet. Without
+/// them every value stays text, which is what these primitives did before.
+fn parse_slots(slots_json: Option<String>) -> Result<Vec<spackle::slot::Slot>, String> {
+    match slots_json {
+        None => Ok(Vec::new()),
+        Some(raw) => serde_json::from_str(&raw).map_err(|e| format!("invalid slots_json: {}", e)),
+    }
+}
+
 // --- exports ---
 
 /// Run every static project check against `project_bundle`. Always
@@ -193,7 +205,12 @@ pub fn validate_slot_data(
 /// `render_file` on the body, then strip the trailing extension
 /// host-side.
 #[wasm_bindgen]
-pub fn render_file(template_bundle: JsValue, target_path: &str, slot_data_json: &str) -> JsValue {
+pub fn render_file(
+    template_bundle: JsValue,
+    target_path: &str,
+    slot_data_json: &str,
+    slots_json: Option<String>,
+) -> JsValue {
     let entries = match decode_bundle(template_bundle) {
         Ok(e) => e,
         Err(msg) => return diag_response_file(target_path, msg),
@@ -218,8 +235,12 @@ pub fn render_file(template_bundle: JsValue, target_path: &str, slot_data_json: 
         Ok(d) => d,
         Err(e) => return diag_response_file(target_path, e),
     };
+    let slots = match parse_slots(slots_json) {
+        Ok(s) => s,
+        Err(e) => return diag_response_file(target_path, e),
+    };
 
-    match spackle::template::render_one_from_memory(&templates, target_path, &slot_data) {
+    match spackle::template::render_one_from_memory(&templates, target_path, &slot_data, &slots) {
         Ok(rendered) => RenderFileResponse {
             bytes: rendered.into_bytes(),
             diagnostics: Vec::new(),
@@ -279,16 +300,21 @@ fn diag_response_file(target_path: &str, message: String) -> JsValue {
 /// diagnostic to a specific path in its UI; callers branch on
 /// `diagnostics`, not on `path` content.
 #[wasm_bindgen]
-pub fn render_path(path_template: &str, slot_data_json: &str) -> JsValue {
+pub fn render_path(
+    path_template: &str,
+    slot_data_json: &str,
+    slots_json: Option<String>,
+) -> JsValue {
     let slot_data = match parse_slot_data(slot_data_json) {
         Ok(d) => d,
         Err(e) => return diag_response_path(path_template, e),
     };
-
-    let context = match tera::Context::from_serialize(&slot_data) {
-        Ok(c) => c,
-        Err(e) => return diag_response_path(path_template, format!("context error: {}", e)),
+    let slots = match parse_slots(slots_json) {
+        Ok(s) => s,
+        Err(e) => return diag_response_path(path_template, e),
     };
+
+    let context = spackle::slot::context_from_data(&slot_data, &slots);
 
     match tera::Tera::one_off(path_template, &context, false) {
         Ok(rendered) => RenderPathResponse {
@@ -501,7 +527,6 @@ fn plan_hooks_native_parity(
 ) -> Vec<spackle::hook::HookPlanEntry> {
     use spackle::hook::HookPlanEntry;
     use spackle::needs::Needy;
-    use tera::Context;
 
     let items: Vec<&dyn Needy> = {
         let mut v: Vec<&dyn Needy> = slots.iter().map(|s| s as &dyn Needy).collect();
@@ -549,19 +574,7 @@ fn plan_hooks_native_parity(
         // Render the command into its full `bash -c` argv, then run the
         // denylist on argv[2] (the `-c` body). Mirrors
         // `spackle::hook::evaluate_hook_plan`.
-        let context = match Context::from_serialize(&running) {
-            Ok(c) => c,
-            Err(e) => {
-                results.push(HookPlanEntry {
-                    key: hook.key.clone(),
-                    command: hook.command.display_argv(),
-                    should_run: false,
-                    skip_reason: Some("template_error".to_string()),
-                    template_errors: vec![format!("context error: {}", e)],
-                });
-                continue;
-            }
-        };
+        let context = spackle::slot::context_from_data(&running, slots);
 
         let argv = match spackle::hook::render_command(&hook.command, &context) {
             Ok(argv) => argv,
@@ -594,7 +607,7 @@ fn plan_hooks_native_parity(
         // A hook whose command templates cleanly but whose `if` is false
         // is a legitimate skip. A hook whose command template breaks is
         // a hard error regardless of conditional.
-        match hook.evaluate_conditional(&running) {
+        match hook.evaluate_conditional(&running, slots) {
             Ok(false) => {
                 results.push(HookPlanEntry {
                     key: hook.key.clone(),

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -72,6 +72,29 @@ The data type of the slot. Can be one of the following:
 type = "String"
 ```
 
+The type is enforced when a value is supplied, and it is also the type the
+value has inside a template. A `Boolean` slot is a boolean and a `Number` slot
+is a number, so these work:
+
+```jinja
+{% if validated %}do a second adversarial review{% endif %}
+{% if reviewers > 1 %}collect every sign-off{% endif %}
+```
+
+Values still cross the API as strings (`"true"`, `"3"`), and spackle converts
+them using the declared type. A value that doesn't parse stays a string rather
+than failing the render; slot validation rejects it earlier. Printed output is
+unchanged: `{{ reviewers }}` prints `3`, not `3.0`.
+
+Slots with no declaration in `spackle.toml` are strings, as is any `String`
+slot.
+
+A template written against the older behaviour, where every value was text,
+may need one edit: `{% if validated == "true" %}` no longer matches, because
+`validated` is a boolean rather than the string `"true"`. Use
+`{% if validated %}` instead. The other common workaround, `{{ count | int }}`,
+still works.
+
 ### needs `string[]`
 
 The slots that the slot depends on.

--- a/docs/ts/api.md
+++ b/docs/ts/api.md
@@ -162,6 +162,8 @@ Empty-directory parity: native `spackle generate` calls `create_dir_all` for eve
 
 **Memory.** Static files stream-copy through `pipeline(createReadStream, createWriteStream)` — peak memory per static is one ~64 KiB Node `highWaterMark` chunk regardless of file size. GB-scale assets are fine. Templated bodies still buffer fully in memory (Tera produces a `String`), but typical templates are KB-scale.
 
+**Slot types in templates.** `generate` already reads the project config, so it passes the slot declarations to every `renderFile` / `renderPath` call. A `Boolean` slot is a boolean inside the template and a `Number` slot is a number, so `{% if flag %}` and `{% if count > 2 %}` behave as written. `slotData` stays `Record<string, string>`.
+
 **Template semantics.** `renderFile` builds a Tera instance per call from a template-source registry — every `.j2` / `.tera` body the host walked — and renders only the requested target. Tera 2's cross-template tags (`{% include %}` and `{% extends %}`) resolve across the project. Tera 2 does not support `{% macro %}` / `{% import %}`. Static assets never enter the registry; only template bodies cross the wasm boundary.
 
 ## `planHooks(projectDir, outDir, data, fs, opts?)`
@@ -305,6 +307,15 @@ function planHooksBundle(
 ```
 
 No bundle-input variant of `generate` / `render` ships — those are disk-walking orchestrators. Browser / custom-source hosts that need bundle-input generation compose the per-file primitives themselves: read the bundle, call `wasm.renderFile` / `wasm.renderPath` per entry via `loadSpackleWasm()`, and assemble results in whatever shape suits them.
+
+Pass the config's `slots` to those two primitives — they take it as an optional trailing argument:
+
+```ts
+wasm.renderFile(bundle, targetPath, slotData, config.slots);
+wasm.renderPath(pathTemplate, slotData, config.slots);
+```
+
+Without it every value is a string, so a `Boolean` slot is the truthy text `"false"` and a `Number` slot cannot be compared numerically. `checkBundle` returns the `config`, so the declarations are already available.
 
 Pair with `MemoryFs.toBundle()` / `MemoryFs.fromBundle()` to inspect inputs / outputs in-memory.
 

--- a/docs/ts/custom-host.md
+++ b/docs/ts/custom-host.md
@@ -86,6 +86,10 @@ const data = {
     _project_name: checkRes.config?.name ?? "project",
     _output_name: "abc-123",
 };
+// Slot declarations decide the type each value has in the template.
+// Omit them and every value is a string, so `{% if flag %}` is true
+// even for "false".
+const slots = checkRes.config?.slots ?? [];
 const ignore = new Set(checkRes.config?.ignore ?? []);
 const segments = (rel: string) => rel.split("/");
 const isIgnored = (rel: string) => segments(rel).some((s) => ignore.has(s));
@@ -104,6 +108,11 @@ const hasConfigAncestor = (rel: string) => {
     return false;
 };
 
+// `renderFile` renders one target out of a registry of every template
+// body, so `{% include %}` / `{% extends %}` resolve across the
+// project. Static assets stay out of it.
+const templateSources = bundle.filter((e) => /\.(j2|tera)$/.test(e.path));
+
 const outFiles: { path: string; bytes: Uint8Array }[] = [];
 const outDirs = new Set<string>();
 for (const entry of bundle) {
@@ -120,12 +129,12 @@ for (const entry of bundle) {
         if (hasConfigAncestor(rel)) continue;
     }
 
-    const pathRes = wasm.renderPath(rel, data);
+    const pathRes = wasm.renderPath(rel, data, slots);
     if (pathRes.diagnostics.length) throw new Error(pathRes.diagnostics[0].message);
     const renderedRel = pathRes.path;
 
     if (isTemplate) {
-        const r = wasm.renderFile(entry.bytes, data, rel);
+        const r = wasm.renderFile(templateSources, entry.path, data, slots);
         if (r.diagnostics.length) throw new Error(r.diagnostics[0].message);
         outFiles.push({ path: renderedRel.replace(/\.(j2|tera)$/, ""), bytes: r.bytes });
     } else {

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -5,7 +5,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use tera::{Context, Tera};
+use tera::Tera;
 
 use crate::fs::{self as fsmod, FileSystem, FileType};
 use crate::slot::Slot;
@@ -50,16 +50,9 @@ pub fn validate_paths<F: FileSystem>(
     skip: &Vec<String>,
     slots: &[Slot],
 ) -> Result<Vec<Error>, Error> {
-    let mut context_data: HashMap<String, String> = slots
-        .iter()
-        .map(|s| (s.key.clone(), String::new()))
-        .collect();
-    context_data.insert("_project_name".to_string(), String::new());
-    context_data.insert("_output_name".to_string(), String::new());
-    let context = Context::from_serialize(&context_data).map_err(|e| Error {
-        source: e.into(),
-        path: src.to_path_buf(),
-    })?;
+    let mut context = crate::slot::placeholder_context(slots);
+    context.insert("_project_name".to_string(), "");
+    context.insert("_output_name".to_string(), "");
 
     let entries = fsmod::walk(fs, src).map_err(|e| Error {
         source: Box::new(e),
@@ -122,8 +115,9 @@ pub fn copy<F: FileSystem>(
     dest: &Path,
     skip: &Vec<String>,
     data: &HashMap<String, String>,
+    slots: &[Slot],
 ) -> Result<CopyResult, Error> {
-    let report = copy_collect(fs, src, dest, skip, data)?;
+    let report = copy_collect(fs, src, dest, skip, data, slots)?;
     if let Some(first) = report.errors.into_iter().next() {
         return Err(first);
     }
@@ -143,6 +137,7 @@ pub fn copy_collect<F: FileSystem>(
     dest: &Path,
     skip: &Vec<String>,
     data: &HashMap<String, String>,
+    slots: &[Slot],
 ) -> Result<CopyReport, Error> {
     let mut copied_count = 0;
     let mut skipped_count = 0;
@@ -202,16 +197,7 @@ pub fn copy_collect<F: FileSystem>(
         let src_path = src.join(&rel_path);
         let dst_path_maybe_template = dest.join(&rel_path);
 
-        let context = match Context::from_serialize(data) {
-            Ok(c) => c,
-            Err(e) => {
-                errors.push(Error {
-                    source: e.into(),
-                    path: src_path.clone(),
-                });
-                continue;
-            }
-        };
+        let context = crate::slot::context_from_data(data, slots);
         let dst_path: PathBuf =
             match Tera::one_off(&dst_path_maybe_template.to_string_lossy(), &context, false) {
                 Ok(path) => path.into(),
@@ -306,6 +292,7 @@ mod tests {
             &dst_dir,
             &vec!["file-0.txt".to_string()],
             &HashMap::from([("foo".to_string(), "bar".to_string())]),
+            &[],
         )
         .unwrap();
 
@@ -344,6 +331,7 @@ mod tests {
             &dst_dir,
             &vec!["file-0.txt".to_string()],
             &HashMap::from([("foo".to_string(), "bar".to_string())]),
+            &[],
         )
         .unwrap();
 
@@ -385,6 +373,7 @@ mod tests {
                 ("template_name".to_string(), "template".to_string()),
                 ("_output_name".to_string(), "foo".to_string()),
             ]),
+            &[],
         )
         .unwrap();
 

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -153,13 +153,14 @@ impl Hook {
     pub fn evaluate_conditional(
         &self,
         context: &HashMap<String, String>,
+        slots: &[Slot],
     ) -> Result<bool, ConditionalError> {
         let conditional = match &self.r#if {
             Some(conditional) => conditional,
             None => return Ok(true),
         };
 
-        let context = Context::from_serialize(context).map_err(ConditionalError::InvalidContext)?;
+        let context = crate::slot::context_from_data(context, slots);
 
         let condition_str = Tera::one_off(conditional, &context, false)
             .map_err(ConditionalError::InvalidTemplate)?;
@@ -564,7 +565,7 @@ pub fn evaluate_hook_plan(
 
         // Evaluate conditional using the running context (includes
         // hook_ran_* for prior hooks).
-        match hook.evaluate_conditional(&running_data) {
+        match hook.evaluate_conditional(&running_data, slots) {
             Ok(false) => {
                 results.push(HookPlanEntry {
                     key: hook.key.clone(),
@@ -592,19 +593,7 @@ pub fn evaluate_hook_plan(
         // semantics: templating failure is a hard error — the hook is NOT
         // runnable, and hook_ran_* is NOT flipped (downstream conditionals
         // see false).
-        let context = match Context::from_serialize(&running_data) {
-            Ok(c) => c,
-            Err(e) => {
-                results.push(HookPlanEntry {
-                    key: hook.key.clone(),
-                    command: hook.command.display_argv(),
-                    should_run: false,
-                    skip_reason: Some("template_error".to_string()),
-                    template_errors: vec![format!("context error: {}", e)],
-                });
-                continue;
-            }
-        };
+        let context = crate::slot::context_from_data(&running_data, slots);
 
         let argv = match render_command(&hook.command, &context) {
             Ok(argv) => argv,
@@ -707,8 +696,7 @@ pub fn run_hooks_stream(
     // hook_ran_* state.
     let mut commands = Vec::new();
     for hook in queued_hooks {
-        let context = Context::from_serialize(data)
-            .map_err(|e| Error::ErrorRenderingTemplate(hook.clone(), e))?;
+        let context = crate::slot::context_from_data(data, slots);
 
         let argv = render_command(&hook.command, &context)
             .map_err(|e| Error::ErrorRenderingTemplate(hook.clone(), e))?;
@@ -738,6 +726,9 @@ pub fn run_hooks_stream(
     }
 
     let slot_data_owned = data.clone();
+    // Owned because the stream outlives this call and re-evaluates
+    // conditionals, which needs the slot types.
+    let slots_owned = slots.clone();
     let hook_keys = hooks.iter().map(|h| h.key.clone()).collect::<Vec<String>>();
 
     Ok(stream! {
@@ -764,7 +755,7 @@ pub fn run_hooks_stream(
                 cond_context.insert(format!("hook_ran_{}", hook), "true".to_string());
             }
 
-            let condition = match hook.evaluate_conditional(&cond_context) {
+            let condition = match hook.evaluate_conditional(&cond_context, &slots_owned) {
                 Ok(condition) => condition,
                 Err(e) => {
                     yield HookStreamResult::HookDone(HookResult {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,11 +175,18 @@ impl Project {
         slot_data.insert("_output_name".to_string(), get_output_name(out_dir));
 
         // Copy all non-template files to the output directory
-        copy::copy(fs, project_dir, &out_dir, &config.ignore, &slot_data)
-            .map_err(GenerateError::CopyError)?;
+        copy::copy(
+            fs,
+            project_dir,
+            &out_dir,
+            &config.ignore,
+            &slot_data,
+            &config.slots,
+        )
+        .map_err(GenerateError::CopyError)?;
 
         // Render template files to the output directory
-        let results = template::fill(fs, project_dir, out_dir, &slot_data)
+        let results = template::fill(fs, project_dir, out_dir, &slot_data, &config.slots)
             .map_err(GenerateError::TemplateError)?;
 
         // Split vector into vector of rendered files and vector of errors
@@ -205,7 +212,14 @@ impl Project {
         data.insert("_project_name".to_string(), self.get_name());
         data.insert("_output_name".to_string(), get_output_name(out_dir));
 
-        copy::copy(fs, &self.path, out_dir, &self.config.ignore, &data)
+        copy::copy(
+            fs,
+            &self.path,
+            out_dir,
+            &self.config.ignore,
+            &data,
+            &self.config.slots,
+        )
     }
 
     pub fn render_templates<F: fs::FileSystem>(
@@ -218,7 +232,7 @@ impl Project {
         data.insert("_project_name".to_string(), self.get_name());
         data.insert("_output_name".to_string(), get_output_name(out_dir));
 
-        template::fill(fs, &self.path, out_dir, &data)
+        template::fill(fs, &self.path, out_dir, &data, &self.config.slots)
     }
 
     /// Render a single-file (`.j2t`) project into a string.

--- a/src/render.rs
+++ b/src/render.rs
@@ -66,7 +66,14 @@ pub fn render<F: FileSystem>(
     // copy_collect's outer `Err` is reserved for non-recoverable
     // preconditions (no writable dest root, no readable src); per-entry
     // failures land in `report.errors` instead.
-    let copy_report = match copy::copy_collect(fs, project_dir, out_dir, &config.ignore, &data) {
+    let copy_report = match copy::copy_collect(
+        fs,
+        project_dir,
+        out_dir,
+        &config.ignore,
+        &data,
+        &config.slots,
+    ) {
         Ok(r) => r,
         Err(fatal) => {
             diagnostics.push(diagnostic::from_copy_error(&fatal));
@@ -83,7 +90,7 @@ pub fn render<F: FileSystem>(
     }
 
     let mut rendered: Vec<template::RenderedFile> = Vec::new();
-    match template::fill(fs, project_dir, out_dir, &data) {
+    match template::fill(fs, project_dir, out_dir, &data, &config.slots) {
         Ok(results) => {
             for r in results {
                 match r {

--- a/src/slot.rs
+++ b/src/slot.rs
@@ -1,6 +1,7 @@
 use colored::Colorize;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt::Display};
+use tera::{Context, Value};
 
 use crate::needs::{is_satisfied, Needy};
 
@@ -87,6 +88,75 @@ impl Slot {
     pub fn get_name(&self) -> String {
         self.name.clone().unwrap_or(self.key.clone())
     }
+}
+
+/// One slot value, converted to the type its slot declares.
+///
+/// Slot data is carried as strings everywhere, because it comes from CLI
+/// flags, TOML defaults and JSON payloads. Tera has real types, so a value
+/// left as text behaves wrongly: a non-empty string is truthy, which makes
+/// `{% if flag %}` true even when `flag` is `false`, and a string cannot be
+/// compared with a number, so `{% if n > 2 %}` is a type error.
+///
+/// A value that doesn't parse as its declared type is left as text rather
+/// than rejected here. [`validate_data`] reports that case with a clearer
+/// message, and a render that skipped validation should still produce output.
+pub fn typed_value(raw: &str, slot_type: &SlotType) -> Value {
+    match slot_type {
+        SlotType::String => Value::from(raw),
+        SlotType::Boolean => raw
+            .parse::<bool>()
+            .map(Value::from)
+            .unwrap_or_else(|_| Value::from(raw)),
+        // Integers first: `5` as an f64 renders as `5.0`, which would change
+        // what an existing template prints for a whole number.
+        SlotType::Number => raw
+            .parse::<i64>()
+            .map(Value::from)
+            .or_else(|_| raw.parse::<f64>().map(Value::from))
+            .unwrap_or_else(|_| Value::from(raw)),
+    }
+}
+
+/// Build the Tera context for a render, giving every value the type its slot
+/// declares. See [`typed_value`] for why.
+///
+/// Keys with no matching slot stay strings: the `_project_name` /
+/// `_output_name` specials, and any extra key the caller passed.
+pub fn context_from_data(data: &HashMap<String, String>, slots: &[Slot]) -> Context {
+    let types: HashMap<&str, &SlotType> = slots
+        .iter()
+        .map(|slot| (slot.key.as_str(), &slot.r#type))
+        .collect();
+
+    let mut context = Context::new();
+    for (key, raw) in data {
+        let value = match types.get(key.as_str()) {
+            Some(slot_type) => typed_value(raw, slot_type),
+            None => Value::from(raw.as_str()),
+        };
+        context.insert_value(key.clone(), value);
+    }
+    context
+}
+
+/// Stand-in context for the static checks, which run before any value is
+/// supplied.
+///
+/// Each slot gets its declared type's zero value rather than an empty string.
+/// Against `""`, a check of `{% if count > 2 %}` reports a comparison error
+/// for a template that renders fine once a value exists.
+pub fn placeholder_context(slots: &[Slot]) -> Context {
+    let mut context = Context::new();
+    for slot in slots {
+        let value = match slot.r#type {
+            SlotType::String => Value::from(""),
+            SlotType::Boolean => Value::from(false),
+            SlotType::Number => Value::from(0_i64),
+        };
+        context.insert_value(slot.key.clone(), value);
+    }
+    context
 }
 
 pub fn validate(slots: &Vec<Slot>) -> Result<(), Error> {
@@ -253,5 +323,167 @@ mod tests {
             .collect::<HashMap<String, String>>();
 
         assert!(validate_data(&data, &slots).is_err());
+    }
+
+    fn slot_of(key: &str, slot_type: SlotType) -> Slot {
+        Slot {
+            key: key.to_string(),
+            r#type: slot_type,
+            ..Default::default()
+        }
+    }
+
+    fn data_of(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    /// Render `body` the way a real render does, so these assert against
+    /// Tera's own semantics.
+    fn render_with(body: &str, data: &[(&str, &str)], slots: &[Slot]) -> String {
+        let context = context_from_data(&data_of(data), slots);
+        tera::Tera::one_off(body, &context, false).expect("render should succeed")
+    }
+
+    #[test]
+    fn typed_value_table() {
+        let cases: Vec<(&str, SlotType, &str)> = vec![
+            ("false", SlotType::Boolean, "false"),
+            ("true", SlotType::Boolean, "true"),
+            ("5", SlotType::Number, "5"),
+            ("-3", SlotType::Number, "-3"),
+            ("3.14", SlotType::Number, "3.14"),
+            ("hello", SlotType::String, "hello"),
+            // Values that don't parse stay text; `validate_data` reports
+            // them, with a message that names the slot.
+            ("yes", SlotType::Boolean, "yes"),
+            ("many", SlotType::Number, "many"),
+        ];
+        for (raw, slot_type, expected) in cases {
+            let value = typed_value(raw, &slot_type);
+            assert_eq!(
+                value.to_string(),
+                expected,
+                "typed_value({:?}, {:?})",
+                raw,
+                slot_type
+            );
+        }
+    }
+
+    #[test]
+    fn typed_value_keeps_whole_numbers_whole() {
+        // An f64 round-trip would print `5.0` and change existing output.
+        assert_eq!(typed_value("5", &SlotType::Number).to_string(), "5");
+        assert_eq!(typed_value("5.5", &SlotType::Number).to_string(), "5.5");
+    }
+
+    #[test]
+    fn boolean_conditionals_follow_the_value() {
+        let slots = vec![slot_of("flag", SlotType::Boolean)];
+        let body = "{% if flag %}YES{% else %}NO{% endif %}";
+
+        assert_eq!(render_with(body, &[("flag", "true")], &slots), "YES");
+        // As text, "false" is non-empty and therefore truthy, so this
+        // used to render YES.
+        assert_eq!(render_with(body, &[("flag", "false")], &slots), "NO");
+    }
+
+    #[test]
+    fn boolean_compares_against_a_bare_literal() {
+        let slots = vec![slot_of("flag", SlotType::Boolean)];
+        let body = "{% if flag == true %}YES{% else %}NO{% endif %}";
+
+        assert_eq!(render_with(body, &[("flag", "true")], &slots), "YES");
+        assert_eq!(render_with(body, &[("flag", "false")], &slots), "NO");
+    }
+
+    #[test]
+    fn boolean_negation_follows_the_value() {
+        let slots = vec![slot_of("flag", SlotType::Boolean)];
+        let body = "{% if not flag %}YES{% else %}NO{% endif %}";
+
+        assert_eq!(render_with(body, &[("flag", "false")], &slots), "YES");
+        assert_eq!(render_with(body, &[("flag", "true")], &slots), "NO");
+    }
+
+    #[test]
+    fn number_comparisons_work() {
+        let slots = vec![slot_of("count", SlotType::Number)];
+        let body = "{% if count > 2 %}YES{% else %}NO{% endif %}";
+
+        assert_eq!(render_with(body, &[("count", "5")], &slots), "YES");
+        assert_eq!(render_with(body, &[("count", "1")], &slots), "NO");
+    }
+
+    #[test]
+    fn zero_is_falsy_like_a_number_rather_than_truthy_like_text() {
+        let slots = vec![slot_of("count", SlotType::Number)];
+        let body = "{% if count %}YES{% else %}NO{% endif %}";
+
+        assert_eq!(render_with(body, &[("count", "0")], &slots), "NO");
+        assert_eq!(render_with(body, &[("count", "1")], &slots), "YES");
+    }
+
+    #[test]
+    fn interpolation_is_unchanged() {
+        let slots = vec![
+            slot_of("flag", SlotType::Boolean),
+            slot_of("count", SlotType::Number),
+            slot_of("name", SlotType::String),
+        ];
+        let out = render_with(
+            "{{ flag }}|{{ count }}|{{ name }}",
+            &[("flag", "false"), ("count", "5"), ("name", "spackle")],
+            &slots,
+        );
+        assert_eq!(out, "false|5|spackle");
+    }
+
+    #[test]
+    fn string_slots_are_left_alone() {
+        // A String slot holding "false" is text, and non-empty text is
+        // truthy. Conversion must not change that.
+        let slots = vec![slot_of("label", SlotType::String)];
+        let body = "{% if label %}YES{% else %}NO{% endif %}";
+
+        assert_eq!(render_with(body, &[("label", "false")], &slots), "YES");
+        assert_eq!(render_with(body, &[("label", "")], &slots), "NO");
+    }
+
+    #[test]
+    fn undeclared_keys_stay_text() {
+        // `_project_name` / `_output_name` and any extra key a caller
+        // passes have no declared type to restore.
+        let out = render_with("{{ _output_name }}", &[("_output_name", "0")], &[]);
+        assert_eq!(out, "0");
+    }
+
+    #[test]
+    fn the_text_comparison_workaround_stops_matching() {
+        // Templates written before this change compared against the text.
+        // A `Boolean` slot is no longer text, so use `{% if flag %}`.
+        let slots = vec![slot_of("flag", SlotType::Boolean)];
+        let body = r#"{% if flag == "true" %}YES{% else %}NO{% endif %}"#;
+
+        assert_eq!(render_with(body, &[("flag", "true")], &slots), "NO");
+    }
+
+    #[test]
+    fn the_int_filter_workaround_still_works() {
+        // The other workaround still works: `int` on a number is a no-op.
+        let slots = vec![slot_of("count", SlotType::Number)];
+        let body = "{% if count | int > 2 %}YES{% else %}NO{% endif %}";
+
+        assert_eq!(render_with(body, &[("count", "5")], &slots), "YES");
+        assert_eq!(render_with(body, &[("count", "1")], &slots), "NO");
+    }
+
+    #[test]
+    fn a_value_that_does_not_parse_still_renders() {
+        let slots = vec![slot_of("flag", SlotType::Boolean)];
+        assert_eq!(render_with("{{ flag }}", &[("flag", "yes")], &slots), "yes");
     }
 }

--- a/src/template.rs
+++ b/src/template.rs
@@ -5,7 +5,7 @@ use std::{
     path::{Path, PathBuf},
     time::Duration,
 };
-use tera::{Context, Tera};
+use tera::Tera;
 use thiserror::Error;
 
 use super::slot::Slot;
@@ -100,13 +100,7 @@ pub fn validate_in_memory(
         })
         .collect();
 
-    let mut context = Context::from_serialize(
-        &slots
-            .iter()
-            .map(|s| (s.key.clone(), ""))
-            .collect::<HashMap<_, _>>(),
-    )
-    .map_err(ValidateError::TeraError)?;
+    let mut context = super::slot::placeholder_context(slots);
     context.insert("_project_name".to_string(), "");
     context.insert("_output_name".to_string(), "");
 
@@ -160,6 +154,7 @@ pub fn render_one_from_memory(
     templates: &HashMap<String, String>,
     target_path: &str,
     data: &HashMap<String, String>,
+    slots: &[Slot],
 ) -> Result<String, FileError> {
     let (tera, mut registry_errs) = build_resilient_registry(templates);
     if let Some(e) = registry_errs.remove(target_path) {
@@ -168,10 +163,7 @@ pub fn render_one_from_memory(
             file: target_path.to_string(),
         });
     }
-    let context = Context::from_serialize(data).map_err(|e| FileError {
-        kind: FileErrorKind::ErrorRenderingContents(e),
-        file: target_path.to_string(),
-    })?;
+    let context = super::slot::context_from_data(data, slots);
     tera.render(target_path, &context).map_err(|e| FileError {
         kind: FileErrorKind::ErrorRenderingContents(e),
         file: target_path.to_string(),
@@ -185,6 +177,7 @@ pub fn render_one_from_memory(
 pub fn render_in_memory(
     templates: &HashMap<String, String>,
     data: &HashMap<String, String>,
+    slots: &[Slot],
 ) -> Result<Vec<Result<RenderedFile, FileError>>, tera::Error> {
     let (tera, registry_errs) = build_resilient_registry(templates);
     let parse_failures: Vec<FileError> = registry_errs
@@ -194,7 +187,7 @@ pub fn render_in_memory(
             file,
         })
         .collect();
-    let context = Context::from_serialize(data)?;
+    let context = super::slot::context_from_data(data, slots);
 
     let template_names = tera.get_template_names();
     let rendered = template_names.into_iter().map(|template_name| {
@@ -325,6 +318,7 @@ pub fn fill<F: FileSystem>(
     project_dir: &Path,
     out_dir: &Path,
     data: &HashMap<String, String>,
+    slots: &[Slot],
 ) -> Result<Vec<Result<RenderedFile, FileError>>, tera::Error> {
     // Collect templates via the fs trait, render in memory (per-file —
     // no accumulating the whole project's output bytes), then write each
@@ -332,7 +326,7 @@ pub fn fill<F: FileSystem>(
     let templates = collect_templates(fs, project_dir)
         .map_err(|e| tera::Error::message(format!("failed to walk project dir: {}", e)))?;
 
-    let rendered = render_in_memory(&templates, data)?;
+    let rendered = render_in_memory(&templates, data, slots)?;
 
     let mut out = Vec::with_capacity(rendered.len());
     for result in rendered {
@@ -499,7 +493,7 @@ mod tests {
                 .map(|(k, v)| (k.to_string(), v.to_string()))
                 .collect();
 
-            let results = render_in_memory(&templates, &data).expect(&format!(
+            let results = render_in_memory(&templates, &data, &[]).expect(&format!(
                 "case {}: render_in_memory should not return Err",
                 c.name
             ));
@@ -543,7 +537,7 @@ mod tests {
         );
         templates.insert("partial.j2".to_string(), "world".to_string());
         let data: HashMap<String, String> = HashMap::new();
-        let out = render_one_from_memory(&templates, "main.j2", &data).expect("render ok");
+        let out = render_one_from_memory(&templates, "main.j2", &data, &[]).expect("render ok");
         assert_eq!(out, "hello world");
     }
 
@@ -560,7 +554,7 @@ mod tests {
         );
         let mut data: HashMap<String, String> = HashMap::new();
         data.insert("who".to_string(), "world".to_string());
-        let out = render_one_from_memory(&templates, "child.j2", &data).expect("render ok");
+        let out = render_one_from_memory(&templates, "child.j2", &data, &[]).expect("render ok");
         assert_eq!(out, "BEGIN hi world END");
     }
 
@@ -575,7 +569,7 @@ mod tests {
             "{{ undefined_var }}".to_string(),
         );
         let data: HashMap<String, String> = HashMap::new();
-        let out = render_one_from_memory(&templates, "target.j2", &data).expect("render ok");
+        let out = render_one_from_memory(&templates, "target.j2", &data, &[]).expect("render ok");
         assert_eq!(out, "ok");
     }
 
@@ -651,7 +645,7 @@ mod tests {
             r#"{% include "nope.j2" %}"#.to_string(),
         );
         let data: HashMap<String, String> = HashMap::new();
-        let results = render_in_memory(&templates, &data).expect("global render ok");
+        let results = render_in_memory(&templates, &data, &[]).expect("global render ok");
         let oks: Vec<String> = results
             .iter()
             .filter_map(|r| r.as_ref().ok())
@@ -706,8 +700,8 @@ mod tests {
             r#"{% include "nope.j2" %}"#.to_string(),
         );
         let data: HashMap<String, String> = HashMap::new();
-        let out =
-            render_one_from_memory(&templates, "target.j2", &data).expect("target should render");
+        let out = render_one_from_memory(&templates, "target.j2", &data, &[])
+            .expect("target should render");
         assert_eq!(out, "ok");
     }
 
@@ -721,7 +715,7 @@ mod tests {
             r#"{% include "nope.j2" %}"#.to_string(),
         );
         let data: HashMap<String, String> = HashMap::new();
-        let err = render_one_from_memory(&templates, "target.j2", &data)
+        let err = render_one_from_memory(&templates, "target.j2", &data, &[])
             .expect_err("missing include should error");
         assert_eq!(err.file, "target.j2");
         assert!(matches!(err.kind, FileErrorKind::ErrorParsingTemplate(_)));
@@ -732,7 +726,8 @@ mod tests {
         let mut templates = HashMap::new();
         templates.insert("target.j2".to_string(), "{% if %}".to_string());
         let data: HashMap<String, String> = HashMap::new();
-        let err = render_one_from_memory(&templates, "target.j2", &data).expect_err("parse err");
+        let err =
+            render_one_from_memory(&templates, "target.j2", &data, &[]).expect_err("parse err");
         assert_eq!(err.file, "target.j2");
         assert!(matches!(err.kind, FileErrorKind::ErrorParsingTemplate(_)));
     }
@@ -804,5 +799,24 @@ mod tests {
                 result,
             );
         }
+    }
+
+    #[test]
+    fn validate_tolerates_a_comparison_on_a_declared_number() {
+        // The static checks run before any value is supplied. Against an
+        // empty-string placeholder this template looks like a type error,
+        // so the placeholder has to carry the declared type.
+        let mut templates = HashMap::new();
+        templates.insert(
+            "out.j2".to_string(),
+            "{% if count > 2 %}many{% endif %}".to_string(),
+        );
+        let slots = vec![super::super::slot::Slot {
+            key: "count".to_string(),
+            r#type: super::super::slot::SlotType::Number,
+            ..Default::default()
+        }];
+
+        assert!(validate_in_memory(&templates, &slots).is_ok());
     }
 }

--- a/tests/fixtures/typed_slots_render/SKILL.md.j2
+++ b/tests/fixtures/typed_slots_render/SKILL.md.j2
@@ -1,0 +1,4 @@
+review the diff
+{% if validated %}do a second adversarial review{% endif %}
+{% if reviewers > 1 %}collect every sign-off{% endif %}
+reviewers={{ reviewers }} validated={{ validated }}

--- a/tests/fixtures/typed_slots_render/spackle.toml
+++ b/tests/fixtures/typed_slots_render/spackle.toml
@@ -1,0 +1,11 @@
+name = "typed-slots-render"
+
+[[slots]]
+key = "validated"
+type = "Boolean"
+default = "false"
+
+[[slots]]
+key = "reviewers"
+type = "Number"
+default = "1"

--- a/tests/templating.rs
+++ b/tests/templating.rs
@@ -29,9 +29,19 @@ fn data(pairs: &[(&str, &str)]) -> HashMap<String, String> {
 /// Run `template::fill` over a scaffolded project and return the rendered
 /// files collected into a sorted `Vec<(relative_path, contents)>`.
 fn fill_all(project: &common::Scaffold, data: &HashMap<String, String>) -> Vec<(String, String)> {
+    fill_all_typed(project, data, &[])
+}
+
+/// `fill_all`, with the slot declarations a real render would carry. They
+/// decide whether a value reaches Tera as text or as its declared type.
+fn fill_all_typed(
+    project: &common::Scaffold,
+    data: &HashMap<String, String>,
+    slots: &[spackle::slot::Slot],
+) -> Vec<(String, String)> {
     let out = out_dir();
     let fs = StdFs::new();
-    let results = template::fill(&fs, &project.path(), out.path(), data)
+    let results = template::fill(&fs, &project.path(), out.path(), data, slots)
         .expect("fill should load templates")
         .into_iter()
         .map(|r| r.expect("render should succeed"))
@@ -371,8 +381,14 @@ fn copy_respects_ignore_patterns() {
 fn error_undefined_variable_in_content() {
     let project = scaffold(&[("bad.j2", "{{ missing_slot }}")]);
     let out = out_dir();
-    let results = template::fill(&StdFs::new(), &project.path(), out.path(), &HashMap::new())
-        .expect("load should succeed");
+    let results = template::fill(
+        &StdFs::new(),
+        &project.path(),
+        out.path(),
+        &HashMap::new(),
+        &[],
+    )
+    .expect("load should succeed");
 
     assert_eq!(results.len(), 1);
     let err = results.into_iter().next().unwrap().unwrap_err();
@@ -389,8 +405,14 @@ fn error_undefined_variable_in_filename() {
     // so rendering the name should fail.
     let project = scaffold(&[("{{ missing_name }}.j2", "body")]);
     let out = out_dir();
-    let results = template::fill(&StdFs::new(), &project.path(), out.path(), &HashMap::new())
-        .expect("load should succeed");
+    let results = template::fill(
+        &StdFs::new(),
+        &project.path(),
+        out.path(),
+        &HashMap::new(),
+        &[],
+    )
+    .expect("load should succeed");
 
     let err = results.into_iter().next().unwrap().unwrap_err();
     assert!(
@@ -409,6 +431,7 @@ fn error_malformed_syntax() {
         &project.path(),
         out_dir().path(),
         &HashMap::new(),
+        &[],
     )
     .expect("load should succeed");
 
@@ -535,4 +558,86 @@ fn generate_fails_when_out_dir_exists() {
         .generate(&StdFs::new(), &project.path(), &dst, &HashMap::new())
         .unwrap_err();
     assert!(matches!(err, GenerateError::AlreadyExists(_)));
+}
+
+// ---------------------------------------------------------------------------
+// declared slot types reach the template
+// ---------------------------------------------------------------------------
+
+fn typed_slot(key: &str, slot_type: spackle::slot::SlotType) -> spackle::slot::Slot {
+    spackle::slot::Slot {
+        key: key.to_string(),
+        r#type: slot_type,
+        ..Default::default()
+    }
+}
+
+/// A template that includes a block only when a boolean is true. Without
+/// the declared type the value arrives as the text "false", which is
+/// truthy, so the block renders at every value.
+#[test]
+fn boolean_slot_gates_a_block() {
+    use spackle::slot::SlotType;
+
+    let project = scaffold(&[(
+        "SKILL.md.j2",
+        "review\n{% if validated %}second pass{% endif %}",
+    )]);
+    let slots = vec![typed_slot("validated", SlotType::Boolean)];
+
+    let off = fill_all_typed(&project, &data(&[("validated", "false")]), &slots);
+    assert_eq!(off[0].1, "review\n");
+
+    let on = fill_all_typed(&project, &data(&[("validated", "true")]), &slots);
+    assert_eq!(on[0].1, "review\nsecond pass");
+}
+
+#[test]
+fn number_slot_compares_numerically() {
+    use spackle::slot::SlotType;
+
+    let project = scaffold(&[("out.j2", "{% if count > 2 %}many{% else %}few{% endif %}")]);
+    let slots = vec![typed_slot("count", SlotType::Number)];
+
+    assert_eq!(
+        fill_all_typed(&project, &data(&[("count", "5")]), &slots)[0].1,
+        "many"
+    );
+    assert_eq!(
+        fill_all_typed(&project, &data(&[("count", "1")]), &slots)[0].1,
+        "few"
+    );
+}
+
+/// Conversion changes conditionals; printed output stays the same.
+#[test]
+fn typed_slots_print_the_same_text_as_before() {
+    use spackle::slot::SlotType;
+
+    let project = scaffold(&[("out.j2", "{{ flag }}|{{ count }}|{{ name }}")]);
+    let slots = vec![
+        typed_slot("flag", SlotType::Boolean),
+        typed_slot("count", SlotType::Number),
+        typed_slot("name", SlotType::String),
+    ];
+
+    let files = fill_all_typed(
+        &project,
+        &data(&[("flag", "false"), ("count", "5"), ("name", "spackle")]),
+        &slots,
+    );
+    assert_eq!(files[0].1, "false|5|spackle");
+}
+
+/// Filenames use the same context, so a name that branches on a boolean
+/// follows the value too.
+#[test]
+fn boolean_slot_gates_a_filename() {
+    use spackle::slot::SlotType;
+
+    let project = scaffold(&[("{% if beta %}beta{% else %}stable{% endif %}.md.j2", "body")]);
+    let slots = vec![typed_slot("beta", SlotType::Boolean)];
+
+    let files = fill_all_typed(&project, &data(&[("beta", "false")]), &slots);
+    assert_eq!(files[0].0, "stable.md");
 }

--- a/ts/src/spackle.ts
+++ b/ts/src/spackle.ts
@@ -377,6 +377,10 @@ export async function generate(
   const outputName = get_output_name(outDir, opts.names?.outputName);
   const data = injectSpecials(slotData, projectName, outputName);
   const ignore = checkRes.config?.ignore ?? [];
+  // The renderer needs the declarations to convert a `Boolean` / `Number`
+  // value to its declared type. Without them `{% if flag %}` is true
+  // whatever `flag` holds.
+  const slots = checkRes.config?.slots ?? [];
 
   // Build the template-source registry once; the wasm renderFile call
   // consumes it for every target template so cross-template tags
@@ -405,7 +409,7 @@ export async function generate(
       if (hasConfigFileAncestor(entry.relPath)) continue;
     }
 
-    const pathRes = wasm.renderPath(entry.relPath, data);
+    const pathRes = wasm.renderPath(entry.relPath, data, slots);
     if (pathRes.diagnostics.length > 0) {
       const d = pathRes.diagnostics[0];
       if (d) return { ok: false, error: `${d.path ?? entry.relPath}: ${d.message}` };
@@ -427,7 +431,7 @@ export async function generate(
     }
 
     if (isTemplate) {
-      const renderRes = wasm.renderFile(templateBundle, entry.relPath, data);
+      const renderRes = wasm.renderFile(templateBundle, entry.relPath, data, slots);
       if (renderRes.diagnostics.length > 0) {
         const d = renderRes.diagnostics[0];
         if (d) return { ok: false, error: `${d.path ?? entry.relPath}: ${d.message}` };
@@ -511,6 +515,9 @@ export async function render(
   const outputName = get_output_name(outDir, opts.names?.outputName);
   const data = injectSpecials(slotData, projectName, outputName);
   const ignore = checkRes.config.ignore ?? [];
+  // See `generate`: without the declarations every value reaches Tera as
+  // text.
+  const slots = checkRes.config.slots ?? [];
 
   const templateBundle = buildTemplateBundle(absProject);
 
@@ -525,7 +532,7 @@ export async function render(
       if (hasConfigFileAncestor(entry.relPath)) continue;
     }
 
-    const pathRes = wasm.renderPath(entry.relPath, data);
+    const pathRes = wasm.renderPath(entry.relPath, data, slots);
     diagnostics.push(...pathRes.diagnostics);
     // On render_name failure, `path` falls back to the input so the
     // walk continues against a stable path.
@@ -537,7 +544,7 @@ export async function render(
     }
 
     if (isTemplate) {
-      const renderRes = wasm.renderFile(templateBundle, entry.relPath, data);
+      const renderRes = wasm.renderFile(templateBundle, entry.relPath, data, slots);
       diagnostics.push(...renderRes.diagnostics);
       if (renderRes.diagnostics.length === 0) {
         fileMap.set(stripTemplateExt(renderedRel), renderRes.bytes);

--- a/ts/src/wasm/runtime.ts
+++ b/ts/src/wasm/runtime.ts
@@ -8,6 +8,7 @@ import type {
   PlanHooksResponse,
   RenderFileResponse,
   RenderPathResponse,
+  Slot,
   SlotData,
   ValidationResponse,
 } from "./types.ts";
@@ -32,9 +33,14 @@ export interface RawWasmExports {
   validateSlotData(projectBundle: unknown, projectDir: string, slotDataJson: string): string;
   /** Returns `{ bytes, diagnostics }` as a `JsValue` object (not a
    * JSON string); the typed wrapper narrows it. */
-  renderFile(templateBundle: unknown, targetPath: string, slotDataJson: string): unknown;
+  renderFile(
+    templateBundle: unknown,
+    targetPath: string,
+    slotDataJson: string,
+    slotsJson?: string | null,
+  ): unknown;
   /** Returns `{ path, diagnostics }` as a `JsValue` object. */
-  renderPath(pathTemplate: string, slotDataJson: string): unknown;
+  renderPath(pathTemplate: string, slotDataJson: string, slotsJson?: string | null): unknown;
   planHooks(
     projectBundle: unknown,
     projectDir: string,
@@ -60,11 +66,16 @@ export interface SpackleWasm {
    * against the bundle. Static asset bytes must stay out of the
    * bundle. The bundle paths and `targetPath` use the same key
    * space. */
-  renderFile(templateBundle: Bundle, targetPath: string, slotData: SlotData): RenderFileResponse;
+  renderFile(
+    templateBundle: Bundle,
+    targetPath: string,
+    slotData: SlotData,
+    slots?: Slot[],
+  ): RenderFileResponse;
   /** Render a single path template (e.g. `"src/{{ project }}.txt"`).
    * On error, `path` falls back to the input — branch on
    * `diagnostics`. */
-  renderPath(pathTemplate: string, slotData: SlotData): RenderPathResponse;
+  renderPath(pathTemplate: string, slotData: SlotData, slots?: Slot[]): RenderPathResponse;
   planHooks(
     projectBundle: Bundle,
     projectDir: string,
@@ -129,18 +140,23 @@ async function initialize(
         raw.validateSlotData(projectBundle, projectDir, JSON.stringify(slotData)),
       ) as ValidationResponse;
     },
-    renderFile(templateBundle, targetPath, slotData) {
+    renderFile(templateBundle, targetPath, slotData, slots) {
       // render_file returns a JsValue object, not a JSON string.
       // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
       return raw.renderFile(
         templateBundle,
         targetPath,
         JSON.stringify(slotData),
+        slots === undefined ? undefined : JSON.stringify(slots),
       ) as RenderFileResponse;
     },
-    renderPath(pathTemplate, slotData) {
+    renderPath(pathTemplate, slotData, slots) {
       // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
-      return raw.renderPath(pathTemplate, JSON.stringify(slotData)) as RenderPathResponse;
+      return raw.renderPath(
+        pathTemplate,
+        JSON.stringify(slotData),
+        slots === undefined ? undefined : JSON.stringify(slots),
+      ) as RenderPathResponse;
     },
     planHooks(projectBundle, projectDir, outDir, data, hookRan) {
       // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion

--- a/ts/tests/spackle.test.ts
+++ b/ts/tests/spackle.test.ts
@@ -610,3 +610,54 @@ describe("checkBundle (in-memory)", () => {
     expect(res.config?.name).toBe("x");
   });
 });
+
+describe("declared slot types reach the template", () => {
+  const cleanup: string[] = [];
+  beforeEach(() => void (cleanup.length = 0));
+  afterEach(async () => {
+    await Promise.all(cleanup.map((p) => rm(p, { recursive: true, force: true })));
+  });
+
+  async function renderTyped(slotData: Record<string, string>) {
+    const ws = await workspace("typed_slots_render");
+    cleanup.push(ws.root);
+    const fs = new DiskFs({ workspaceRoot: ws.root });
+    const res = await generate(ws.projectDir, ws.outDir, slotData, fs);
+    expect(res.ok).toBe(true);
+    return readFile(join(ws.outDir, "SKILL.md"), "utf8");
+  }
+
+  test("a false boolean omits its block", async () => {
+    const out = await renderTyped({ validated: "false", reviewers: "1" });
+    expect(out).not.toContain("do a second adversarial review");
+  });
+
+  test("a true boolean includes its block", async () => {
+    const out = await renderTyped({ validated: "true", reviewers: "1" });
+    expect(out).toContain("do a second adversarial review");
+  });
+
+  test("a number compares numerically rather than as text", async () => {
+    expect(await renderTyped({ validated: "false", reviewers: "3" })).toContain(
+      "collect every sign-off",
+    );
+    expect(await renderTyped({ validated: "false", reviewers: "1" })).not.toContain(
+      "collect every sign-off",
+    );
+  });
+
+  test("interpolated values print exactly as before", async () => {
+    const out = await renderTyped({ validated: "false", reviewers: "3" });
+    expect(out).toContain("reviewers=3 validated=false");
+  });
+
+  test("check accepts a numeric comparison before any value is supplied", async () => {
+    // The static check renders against placeholders. Those carry the
+    // declared type too, so a correct template isn't reported as broken.
+    const ws = await workspace("typed_slots_render");
+    cleanup.push(ws.root);
+    const fs = new DiskFs({ workspaceRoot: ws.root });
+    const res = await check(ws.projectDir, fs);
+    expect(res.diagnostics).toEqual([]);
+  });
+});


### PR DESCRIPTION
## The bug

A slot declared `type = "Boolean"` is type-checked when its value is supplied, but the type does not reach the template. The value arrives in Tera as the text `"false"`, and a non-empty string is truthy, so the template renders without error and takes the wrong branch:

```jinja
{% if validated %}        {# true even when validated = false #}
{% if not validated %}    {# always false #}
{% if validated == true %}{# never matches, text vs bool #}
```

A `Number` slot has the same cause. Tera will not compare a string with an integer, so the comparison is an error rather than a wrong answer:

```jinja
{% if count %}            {# true even when count = 0 #}
{% if count > 2 %}        {# error: Cannot compare `string` with `i64` #}
```

(In 0.6.1, built against an older Tera, that comparison was false at every value instead of erroring.)

Only the string forms work today: `validated == "true"`, `count | int > 2`.

`validate_slot_data` does enforce the declared type — `{ validated: "yes" }` reports `expected a Boolean`. So the type is known at validation time and lost by render time.

## The fix

Pass the slot declarations to the code that builds the Tera context.

- `slot::typed_value` / `slot::context_from_data` convert each value to its declared type. Keys with no matching slot (`_project_name`, `_output_name`, caller extras) stay text. A value that does not parse stays text rather than failing the render; `validate_data` reports that case with a clearer message.
- All render paths go through it: `template::fill` / `render_in_memory` / `render_one_from_memory`, `copy` / `copy_collect` for path templates, hook conditionals and command templating, and the wasm `render_file` / `render_path`.
- `slot::placeholder_context` does the same for the static checks, which run before any value is supplied. Against empty-string placeholders, `{% if count > 2 %}` was reported as a type error even though it renders fine once a value exists. Each placeholder now uses its declared type's zero value.

Slot data still crosses every API as `Map<String, String>` / `Record<string, string>`.

### wasm / TS surface

`render_file` and `render_path` take a new optional trailing `slots_json`:

```ts
wasm.renderFile(templateBundle, targetPath, slotData, slots?);
wasm.renderPath(pathTemplate, slotData, slots?);
```

It is optional so a host that has not parsed the config still renders, with the old text behaviour. The TS orchestrators (`generate`, `render`) have the config already and always pass it, so disk-path callers need no change.

## Compatibility

One break: `{% if flag == "true" %}` no longer matches, because `flag` is a boolean rather than the string `"true"`. Use `{% if flag %}` instead. The other workaround, `{{ count | int }}`, still works. Both have tests.

Printed output is unchanged. `typed_value` parses `i64` before `f64`, so a whole number still prints as `5`, not `5.0`.

## Tests

- `src/slot.rs` — 12 tests over `typed_value` / `context_from_data`, checked against real Tera renders: truthiness, negation, comparison with a bare literal, numeric comparison, `0` being falsy, `String` slots unchanged, undeclared keys unchanged, unparseable values still rendering, and both compatibility cases above.
- `src/template.rs` — the static check accepts a comparison on a declared `Number`.
- `tests/templating.rs` + `tests/fixtures/typed_slots_render/` — end to end: a boolean gates a block, a number compares numerically, a boolean gates a filename, and printed output is byte-identical to before.
- `ts/tests/spackle.test.ts` — the same cases through `generate` with `DiskFs`, plus `check` accepting a numeric comparison before values exist.

`cargo test --workspace` (171) and `bun test` in `ts/` (100) pass. `cargo fmt`, `oxlint`, `oxfmt` and `tsc --noEmit` are clean.

## Docs

`docs/configuration.md` (slot `type`, plus the compatibility note), `docs/ts/api.md` (`generate` semantics and the bundle pass-through composition), and the custom-host walkthrough, which now passes `config.slots` to its primitive calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
